### PR TITLE
A quick note about attachments in the admin tool

### DIFF
--- a/docs/tutorial-attachments.rst
+++ b/docs/tutorial-attachments.rst
@@ -150,4 +150,9 @@ In the admin tool
 
 The Remote Settings administration tool supports attachments as well. If a collection has a record schema and attachments are "enabled" for that collection, then editors will be able to upload attachments as part of editing records.
 
-You can enable attachments on a collection on the edit screen by checking the "File attachment" section. The checkboxes here correspond to the ``attachment`` field of the collection's data.
+The controls for attachments in a given collection are in the ``attachment`` field in the collection data. ``attachment`` should be an object and it can have the following properties:
+
+- ``enabled``: boolean, true to enable attachments for this collection
+- ``required``: boolean, true if records in this collection must have an attachment
+
+In stage, you can also enable attachments on a collection on the edit screen by checking the "File attachment" section.

--- a/docs/tutorial-attachments.rst
+++ b/docs/tutorial-attachments.rst
@@ -150,9 +150,7 @@ In the admin tool
 
 The Remote Settings administration tool supports attachments as well. If a collection has a record schema and attachments are "enabled" for that collection, then editors will be able to upload attachments as part of editing records.
 
-The controls for attachments in a given collection are in the ``attachment`` field in the collection data. ``attachment`` should be an object and it can have the following properties:
+The controls for attachments in a given collection are in the ``attachment`` field in the collection data (probably located in the ``remote-settings-permissions`` repo). ``attachment`` should be an object and it can have the following properties:
 
 - ``enabled``: boolean, true to enable attachments for this collection
 - ``required``: boolean, true if records in this collection must have an attachment
-
-In stage, you can also enable attachments on a collection on the edit screen by checking the "File attachment" section.

--- a/docs/tutorial-attachments.rst
+++ b/docs/tutorial-attachments.rst
@@ -144,3 +144,10 @@ About compression
 The server does not compress the files.
 
 We plan to enable compression at the HTTP level (`Bug 1339114 <https://bugzilla.mozilla.org/show_bug.cgi?id=1339114>`_) for when clients fetch the attachment using the ``Accept-Encoding: gzip`` request header.
+
+In the admin tool
+-----------------
+
+The Remote Settings administration tool supports attachments as well. If a collection has a record schema and attachments are "enabled" for that collection, then editors will be able to upload attachments as part of editing records.
+
+You can enable attachments on a collection on the edit screen by checking the "File attachment" section. The checkboxes here correspond to the ``attachment`` field of the collection's data.


### PR DESCRIPTION
This spun out of a discussion on Slack. Collections without attachments "enabled" don't have an attachment field in edit records, which can be surprising/seem like a silent failure if you don't know what's going on.

More documentation might be needed in order to describe what you need to do to move to prod with attachments or something like that, but I thought this would be a good first step. It also isn't really clear whether this belongs as part of the kinto-admin documentation, but the kinto-admin documentation ... doesn't really exist, maybe because it's so WYSIWYG. Rather than try to define a structure there, I thought I would settle for adding something to the existing structure here.

I'm not 100% sure that these are the only requirements but I want to submit this before I forget.