### PR TITLE
Add reference to how to edit STAGE/PROD manifest to add users

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -61,6 +61,7 @@ It is recommended to keep your Remote Settings records small, especially if you 
 
 By default, all records are made available to all users. If you want to control which users should have a particular entry, you can add a ``filter_expression`` field (see :ref:`target filters <target-filters>`).
 
+.. _collection-manifests:
 
 Collection manifests
 --------------------

--- a/docs/tutorial-multi-signoff.rst
+++ b/docs/tutorial-multi-signoff.rst
@@ -23,6 +23,11 @@ This guide assumes you have already installed and set up the following:
 
 We'll refer the running instance as ``$SERVER`` (eg. ``http://localhost:8888/v1`` or ``https://settings-writer.prod.mozaws.net/v1`` via the VPN).
 
+.. seealso::
+
+    If you need to give additional users access to your collection on STAGE/PROD you must edit the :ref:`collection manifest <https://remote-settings.readthedocs.io/en/latest/getting-started.html#collection-manifests>`.
+
+
 Introduction
 ------------
 

--- a/docs/tutorial-multi-signoff.rst
+++ b/docs/tutorial-multi-signoff.rst
@@ -23,9 +23,9 @@ This guide assumes you have already installed and set up the following:
 
 We'll refer the running instance as ``$SERVER`` (eg. ``http://localhost:8888/v1`` or ``https://settings-writer.prod.mozaws.net/v1`` via the VPN).
 
-.. seealso::
+.. note::
 
-    If you need to give additional users access to your collection on STAGE/PROD you must edit the `collection manifest <https://remote-settings.readthedocs.io/en/latest/getting-started.html#collection-manifests>`.
+    If you need to give additional users access to your collection on STAGE/PROD you must edit the :ref:`collection manifest <collection-manifests>`.
 
 
 Introduction

--- a/docs/tutorial-multi-signoff.rst
+++ b/docs/tutorial-multi-signoff.rst
@@ -25,7 +25,7 @@ We'll refer the running instance as ``$SERVER`` (eg. ``http://localhost:8888/v1`
 
 .. seealso::
 
-    If you need to give additional users access to your collection on STAGE/PROD you must edit the :ref:`collection manifest <https://remote-settings.readthedocs.io/en/latest/getting-started.html#collection-manifests>`.
+    If you need to give additional users access to your collection on STAGE/PROD you must edit the `collection manifest <https://remote-settings.readthedocs.io/en/latest/getting-started.html#collection-manifests>`.
 
 
 Introduction


### PR DESCRIPTION
Someone (like me) trying to figure out how to manage user permissions for a collection is likely to go to the multi-signoff tutorial. This adds a small comment at the top to redirect them to the "getting started" page.