### PR TITLE
Remote Settings Dev Tools is the canonical way to switch environments

### DIFF
--- a/docs/tutorial-dev-server.rst
+++ b/docs/tutorial-dev-server.rst
@@ -22,7 +22,12 @@ This guide assumes you have already installed and set up the following:
 Introduction
 ------------
 
-We run a public instance of Kinto, the underlying software of Remote Settings, at https://kinto.dev.mozaws.net/v1
+Remote Settings is built on top of a project called Kinto. As a
+service to the Kinto community, Mozilla hosts a public instance of
+Kinto at https://kinto.dev.mozaws.net/v1. Although this server is not
+officially maintained and has no official connection with the Remote
+Settings project, it can be convenient to use it when exploring Remote
+Settings.
 
 Several authentication options are available. We will use local accounts and Basic Auth for the sake of simplicity.
 
@@ -95,13 +100,17 @@ And it should be listed in the monitor/changes endpoint:
 Prepare the client
 ------------------
 
-The following preference must be created/changed to the following values in ``about:config`` (*or use the Dev Tools*):
-
-* ``services.settings.server`` : ``https://kinto.dev.mozaws.net/v1``
+There is no officially "blessed" way to point the client at the dev
+server. Unlike other environments, the `Remote Settings dev tools
+<https://github.com/mozilla-extensions/remote-settings-devtools/>`_
+cannot be used for this purpose. You can change the
+``services.settings.server`` preference if you like, but because the
+data in the dev server is not signed, you will get signature
+verification errors.
 
 .. important::
 
-    Those are critical preferences, you should use a dedicated Firefox profile for development.
+    This is a critical preference, you should use a dedicated Firefox profile for development.
 
 From your code, or the browser console, register the new collection by listening to the ``sync`` event:
 

--- a/docs/tutorial-local-server.rst
+++ b/docs/tutorial-local-server.rst
@@ -260,10 +260,11 @@ The ``main-preview`` and ``main`` buckets are (re)initialized with read-only per
 Prepare the client
 ------------------
 
-The following preferences must be changed to the following values in ``about:config``:
-
-* ``services.settings.server`` : ``http://localhost:8888/v1``
-* ``security.content.signature.root_hash`` : ``5E:36:F2:14:DE:82:3F:8B:29:96:89:23:5F:03:41:AC:AF:A0:75:AF:82:CB:4C:D4:30:7C:3D:B3:43:39:2A:FE``
+The official way to point the client at another server is using the
+`Remote Settings dev tools
+<https://github.com/mozilla-extensions/remote-settings-devtools>`_. This
+tool can set the constellation of preferences necessary to operate
+correctly with your local server.
 
 .. seealso::
 


### PR DESCRIPTION
Fixes #108.

I wasn't really sure what to do about the `dev` environment. As far as I can tell, it's impossible to use correctly, so maybe we should just delete the whole article?