### PR TITLE
improving wording about target filters to make their purpose clearer

### DIFF
--- a/docs/target-filters.rst
+++ b/docs/target-filters.rst
@@ -3,14 +3,12 @@
 Target filters
 ==============
 
-By default, all records are made available to all users.
+By default all records in a collection are made available.  However, there are some use cases where it is more practical to use a single server side collection and filter record visibility in the browser.  Target filters allows for these use cases.
 
-When defined on a particular record, target filters describe which users should have it.
-
-Basically, filters are conditional expressions executed locally in the client's browser and, if they pass, the corresponding record is available. Filters have access to information about the user, such as their locale, addons, and Firefox version.
+Filters are conditional expressions evaluated in the client's browser and, if they pass, the corresponding record is available. Filters have access to information about the user, such as their locale, addons, and Firefox version.
 
 .. important::
-   With target filters, the list of records is filtered but every records are synchronized everywhere.
+   All records are downloaded to Firefox.  Filters only control what is returned by ``.get()`` or the ``sync`` event.
 
 
 How?

--- a/docs/target-filters.rst
+++ b/docs/target-filters.rst
@@ -3,7 +3,7 @@
 Target filters
 ==============
 
-By default all records in a collection are made available.  However, there are some use cases where it is more practical to use a single server side collection and filter record visibility in the browser.  Target filters allows for use cases.
+By default all records in a collection are made available.  However, there are some use cases where it is more practical to use a single server side collection and filter record visibility in the browser.  Target filters allows for these use cases.
 
 Filters are conditional expressions evaluated in the client's browser and, if they pass, the corresponding record is available. Filters have access to information about the user, such as their locale, addons, and Firefox version.
 

--- a/docs/target-filters.rst
+++ b/docs/target-filters.rst
@@ -3,12 +3,15 @@
 Target filters
 ==============
 
-By default all records in a collection are made available.  However, there are some use cases where it is more practical to use a single server side collection and filter record visibility in the browser.  Target filters allows for these use cases.
+By default all records in a collection are made available.  However, there are some use cases where it is more practical to use a single server side collection and filter record visibility in the browser.  Target filters allows for use cases.
 
 Filters are conditional expressions evaluated in the client's browser and, if they pass, the corresponding record is available. Filters have access to information about the user, such as their locale, addons, and Firefox version.
 
 .. important::
    All records are downloaded to Firefox.  Filters only control what is returned by ``.get()`` or the ``sync`` event.
+
+.. important::
+   The ideal use case for target filters is to use a single collection to service a small number (dozens) of different groups of users.  Filtering by channel, browser version or locale are good use cases.
 
 
 How?


### PR DESCRIPTION
I think this is all we need to close #111.  

During the work week it wasn't clear what the intended purpose of target filters is.  To allow for a single server side collection to serve many a small subset of user groups. 

An unintended consequence that occurred is that target filtering seems suitable for experimentation.  To be suitable we would need to maintain parity with the experiment platform's (normandy, normandy dev tools, filter objects, capabilities, suitabilities, etc) targeting feature set. 

Maintaining parity would diverge from the original purpose and create additional engineering overhead. 

This doc update is meant to make clear what the purpose and ideal usage of target filtering is. 