### PR TITLE
Fix text accidentally included in a code block of target-filters.rst

### DIFF
--- a/docs/target-filters.rst
+++ b/docs/target-filters.rst
@@ -480,7 +480,7 @@ Advanced: Testing Filter Expressions in the Browser Console
         const { RemoteSettings } = ChromeUtils.import("resource://services-settings/remote-settings.js", {});
         const client = RemoteSettings("a-key");
 
-    The following lines create a local record with a filter expression field and fetch the current settings list.
+   The following lines create a local record with a filter expression field and fetch the current settings list.
 
    .. code-block:: javascript
 


### PR DESCRIPTION
It was accidentally indented so it was included in the code block at https://remote-settings.readthedocs.io/en/latest/target-filters.html#advanced-testing-filter-expressions-in-the-browser-console