### PR TITLE
Ship default configuration (fixes #151)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@ __pycache__/
 *$py.class
 .venv/
 kinto-logo.png
-config/kinto.ini
-config/development.ini
-server.ini
 .pytest_cache/
 
 # C extensions

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ the version control of each dependency.
 - Read settings from environment variables (eg. ``KINTO_SIGNER_RESOURCES="..."``)
 - Default value for ``kinto.signer.resources`` is now ``/buckets/main-workspace -> /buckets/main-preview -> /buckets/main``
 - Now ship default configuration files to run a local instance of Remote Settings out of the box (see the *Setup a Local Server* tutorial)
+- The container can now run by just setting the ``KINTO_INI`` environment variable ``docker run -e KINTO_INI=config/testing.ini mozilla/remote-settings``
 
 **Bug Fixes**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ the version control of each dependency.
   This is useful for testing or when using disposable containers.
 - Read settings from environment variables (eg. ``KINTO_SIGNER_RESOURCES="..."``)
 - Default value for ``kinto.signer.resources`` is now ``/buckets/main-workspace -> /buckets/main-preview -> /buckets/main``
+- Now ship default configuration files to run a local instance of Remote Settings out of the box (see the *Setup a Local Server* tutorial)
 
 **Bug Fixes**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ the version control of each dependency.
 - Default value for ``kinto.signer.resources`` is now ``/buckets/main-workspace -> /buckets/main-preview -> /buckets/main``
 - Now ship default configuration files to run a local instance of Remote Settings out of the box (see the *Setup a Local Server* tutorial)
 - The container can now run by just setting the ``KINTO_INI`` environment variable ``docker run -e KINTO_INI=config/testing.ini mozilla/remote-settings``
+- The container now runs without custom configuration with ``docker run mozilla/remote-settings``
 
 **Bug Fixes**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ the version control of each dependency.
   container. Instead of adding the source code to the ``PYTHONPATH``, we ``pip install`` it.
 - Group names for editors and reviewers are now always ``{collection_id}-editors`` and
   ``{collection_id}-reviewers`` (fixes #149)
+- The container loads the ``.ini`` file from ``config./example.ini`` instead of ``/etc/kinto.ini`` by default.
 
 **New Features**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ COPY --from=compile /dogstatsd_plugin.so .
 
 ENV PYTHONUNBUFFERED=1 \
     PORT=8888 \
+    KINTO_INI=/etc/kinto.ini \
     PATH="/opt/venv/bin:$PATH"
 
 # add a non-privileged user for installing and running
@@ -55,6 +56,9 @@ RUN chown 10001:10001 /app && \
 
 COPY . .
 RUN pip install ./kinto-remote-settings
+
+# Use the example config as default.
+RUN mv config/example.ini /etc/kinto.ini
 
 # Generate local key pair to simplify running without Autograph out of the box (see `config/testing.ini`)
 RUN python -m kinto_remote_settings.signer.generate_keypair /app/ecdsa.private.pem /app/ecdsa.public.pem
@@ -68,4 +72,4 @@ EXPOSE $PORT
 
 # Run uwsgi by default
 ENTRYPOINT ["/bin/bash", "/app/bin/run.sh"]
-CMD ["uwsgi", "--ini", "/etc/kinto.ini"]
+CMD uwsgi --ini ${KINTO_INI}

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ RUN chown 10001:10001 /app && \
 COPY . .
 RUN pip install ./kinto-remote-settings
 
+# Generate local key pair to simplify running without Autograph out of the box (see `config/testing.ini`)
+RUN python -m kinto_remote_settings.signer.generate_keypair /app/ecdsa.private.pem /app/ecdsa.public.pem
+
 # Drop down to unprivileged user
 RUN chown -R 10001:10001 /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ COPY --from=compile /dogstatsd_plugin.so .
 
 ENV PYTHONUNBUFFERED=1 \
     PORT=8888 \
-    KINTO_INI=/etc/kinto.ini \
+    KINTO_INI=config/example.ini \
     PATH="/opt/venv/bin:$PATH"
 
 # add a non-privileged user for installing and running
@@ -56,9 +56,6 @@ RUN chown 10001:10001 /app && \
 
 COPY . .
 RUN pip install ./kinto-remote-settings
-
-# Use the example config as default.
-RUN mv config/example.ini /etc/kinto.ini
 
 # Generate local key pair to simplify running without Autograph out of the box (see `config/testing.ini`)
 RUN python -m kinto_remote_settings.signer.generate_keypair /app/ecdsa.private.pem /app/ecdsa.public.pem

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ else
 	@echo PostgreSQL not installed. Please install PostgreSQL to use this command.
 endif
 
+start:
+	make build
+	docker-compose up
+
 stop:
 	docker-compose stop
 

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,19 @@ This *Remote Settings* repository contains the following:
 **The most important function of this repository is to build a Docker image
 with a set of known working dependencies and then ship that to DockerHub.**
 
+
+Run
+---
+
+You need Docker and ``docker-compose``. Ensure `buildkit <https://docs.docker.com/develop/develop-images/build_enhancements/>`_ is enabled on your Docker engine.
+
+.. code-block:: shell
+
+    make start
+
+Your *Remote Settings* instance is now ready at http://localhost:8888. See the `*Setup a Local Server* <https://remote-settings.readthedocs.io/en/latest/tutorial-local-server.html>`_ tutorial for more details.
+
+
 Test Locally
 ------------
 
@@ -47,8 +60,7 @@ After this setup is complete, tests can be run with ``pytest`` using ``make``:
 
 **Integration Tests**
 
-You need Docker and ``docker-compose``. Ensure `buildkit <https://docs.docker.com/develop/develop-images/build_enhancements/>`_ is enabled on your Docker engine.
-The simplest way to test that all is working as expected is to run:
+With Docker and docker-compose, test that all components are working as expected with:
 
 .. code-block:: shell
 
@@ -56,7 +68,7 @@ The simplest way to test that all is working as expected is to run:
 
 .. note::
 
-    The ``run web migrate`` command is only needed once, to prime the
+    The ``docker-compose run web migrate`` command is only needed once, to prime the
     PostgreSQL server (this is done automatically for you in the make command).
     You can flush all the Kinto data in your local persistent PostgreSQL with
     ``curl -XPOST http://localhost:8888/v1/__flush__``

--- a/app.wsgi
+++ b/app.wsgi
@@ -10,8 +10,7 @@ from kinto import main
 here = os.path.dirname(__file__)
 
 ini_path = os.environ.get('KINTO_INI')
-if ini_path is None:
-    ini_path = os.path.join(here, 'config', 'kinto.ini')
+assert ini_path, "'KINTO_INI' not set"
 
 # If, for some reason you accidentally get the config file path wrong
 # you'll get really cryptic errors from `logging.config.fileConfig(ini_path)`

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-: "${KINTO_INI:=config/example.ini}"
-
 usage() {
   echo "usage: ./bin/run.sh migrate|start|uwsgistart|bash|whatevercommandyouwant"
   exit 1
@@ -18,7 +16,7 @@ case $1 in
     kinto start --ini $KINTO_INI
     ;;
   uwsgistart)
-    KINTO_INI=$KINTO_INI uwsgi --http :8888 --ini $KINTO_INI
+    uwsgi --http :$PORT --ini $KINTO_INI
     ;;
   *)
     exec "$@"

--- a/config/example.ini
+++ b/config/example.ini
@@ -153,9 +153,6 @@ kinto.attachment.base_path = /tmp
 # Kinto signer
 #
 kinto.signer.resources = /buckets/main-workspace -> /buckets/main-preview -> /buckets/main
-kinto.signer.editors_group = {collection_id}-editors
-kinto.signer.reviewers_group = {collection_id}-reviewers
-
 kinto.signer.to_review_enabled = true
 kinto.signer.signer_backend = kinto_remote_settings.signer.backends.autograph
 

--- a/config/local.ini
+++ b/config/local.ini
@@ -80,11 +80,10 @@ port = 8888
 
 [uwsgi]
 wsgi-file = app.wsgi
-http-socket = 0.0.0.0:8888
+socket = /tmp/kinto.sock
 master = true
 module = kinto
 static-map = /attachments=/tmp/attachments
-
 
 #
 # Logging

--- a/config/local.ini
+++ b/config/local.ini
@@ -1,0 +1,118 @@
+#
+# Configuration for a local instance:
+#
+# - Autograph at http://autograph-server:8000
+# - Multi-signoff enabled
+# - Authentication via accounts
+#
+[app:main]
+use = egg:kinto
+
+kinto.project_name = Remote Settings LOCAL
+
+kinto.includes = kinto.plugins.admin
+                 kinto.plugins.accounts
+                 kinto.plugins.history
+                 kinto_emailer
+                 kinto_attachment
+                 kinto_remote_settings
+
+kinto.storage_backend = kinto.core.storage.memory
+kinto.storage_url =
+kinto.cache_backend = kinto.core.cache.memory
+kinto.cache_url =
+kinto.permission_backend = kinto.core.permission.memory
+kinto.permission_url =
+
+kinto.experimental_permissions_endpoint = true
+kinto.experimental_collection_schema_validation = true
+
+multiauth.policies = account
+multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
+kinto.userid_hmac_secret = 284461170acd78f0be0827ef514754937474d7c922191e4f78be5c1d232b38c4
+
+kinto.account_create_principals = system.Everyone
+kinto.account_write_principals = account:admin
+
+kinto.bucket_create_principals = system.Authenticated
+kinto.bucket_write_principals = account:admin
+
+#
+# Kinto attachment
+#
+
+kinto.attachment.base_path = /tmp/attachments
+kinto.attachment.base_url =
+# See uwsgi static-map setting
+kinto.attachment.extra.base_url = http://localhost:8888/attachments
+kinto.attachment.folder = {bucket_id}/{collection_id}
+
+
+#
+# Kinto Remote Settings
+#
+
+kinto.changes.resources = /buckets/main
+
+kinto.signer.resources = /buckets/main-workspace -> /buckets/main-preview -> /buckets/main
+
+kinto.signer.auto_create_resources = true
+
+kinto.signer.signer_backend = kinto_remote_settings.signer.backends.autograph
+# Use credentials from https://github.com/mozilla-services/autograph/blob/5b4a473/autograph.yaml
+kinto.signer.autograph.hawk_id = kintodev
+kinto.signer.autograph.hawk_secret = 3isey64n25fim18chqgewirm6z2gwva1mas0eu71e9jtisdwv6bd
+
+
+#
+# Simple daemon (see `run.sh start`)
+#
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 8888
+
+
+#
+# Performant daemon (see `run.sh uwsgistart`)
+#
+
+[uwsgi]
+wsgi-file = app.wsgi
+http-socket = 0.0.0.0:8888
+master = true
+module = kinto
+static-map = /attachments=/tmp/attachments
+
+
+#
+# Logging
+#
+
+[loggers]
+keys = root, kinto
+
+[handlers]
+keys = console
+
+[formatters]
+keys = color
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_kinto]
+level = DEBUG
+handlers = console
+qualname = kinto
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = color
+
+[formatter_color]
+class = logging_color_formatter.ColorFormatter

--- a/config/local.ini
+++ b/config/local.ini
@@ -38,6 +38,12 @@ kinto.bucket_create_principals = system.Authenticated
 kinto.bucket_write_principals = account:admin
 
 #
+# Kinto history
+#
+kinto.history.exclude_resources = /buckets/main-preview
+                                  /buckets/main
+
+#
 # Kinto attachment
 #
 
@@ -54,7 +60,10 @@ kinto.attachment.folder = {bucket_id}/{collection_id}
 
 kinto.changes.resources = /buckets/main
 
-kinto.signer.resources = /buckets/main-workspace -> /buckets/main-preview -> /buckets/main
+kinto.signer.resources =
+    /buckets/main-workspace           -> /buckets/main-preview           -> /buckets/main
+    /buckets/security-state-workspace -> /buckets/security-state-preview -> /buckets/security-state
+    /buckets/staging                  -> /buckets/preview                -> /buckets/blocklists
 
 kinto.signer.auto_create_resources = true
 

--- a/config/testing.ini
+++ b/config/testing.ini
@@ -35,6 +35,12 @@ kinto.bucket_write_principals = system.Everyone
 kinto.bucket_read_principals = system.Everyone
 
 #
+# Kinto history
+#
+kinto.history.exclude_resources = /buckets/main-preview
+                                  /buckets/main
+
+#
 # Kinto attachment
 #
 
@@ -51,7 +57,10 @@ kinto.attachment.folder = {bucket_id}/{collection_id}
 
 kinto.changes.resources = /buckets/main
 
-kinto.signer.resources = /buckets/main-workspace -> /buckets/main-preview -> /buckets/main
+kinto.signer.resources =
+    /buckets/main-workspace           -> /buckets/main-preview           -> /buckets/main
+    /buckets/security-state-workspace -> /buckets/security-state-preview -> /buckets/security-state
+    /buckets/staging                  -> /buckets/preview                -> /buckets/blocklists
 
 kinto.signer.to_review_enabled = false
 

--- a/config/testing.ini
+++ b/config/testing.ini
@@ -11,7 +11,6 @@ use = egg:kinto
 kinto.project_name = Remote Settings TESTING
 
 kinto.includes = kinto.plugins.admin
-                 kinto.plugins.accounts
                  kinto.plugins.history
                  kinto_emailer
                  kinto_attachment

--- a/config/testing.ini
+++ b/config/testing.ini
@@ -1,0 +1,116 @@
+#
+# Configuration for testing purposes:
+#
+# - no authentication
+# - multi-signoff disabled
+# - signing using ECDSA keys
+#
+[app:main]
+use = egg:kinto
+
+kinto.project_name = Remote Settings TESTING
+
+kinto.includes = kinto.plugins.admin
+                 kinto.plugins.accounts
+                 kinto.plugins.history
+                 kinto_emailer
+                 kinto_attachment
+                 kinto_remote_settings
+
+kinto.storage_backend = kinto.core.storage.memory
+kinto.storage_url =
+kinto.cache_backend = kinto.core.cache.memory
+kinto.cache_url =
+kinto.permission_backend = kinto.core.permission.memory
+kinto.permission_url =
+
+kinto.experimental_permissions_endpoint = true
+kinto.experimental_collection_schema_validation = true
+
+kinto.account_create_principals = system.Everyone
+kinto.account_write_principals = system.Everyone
+kinto.account_read_principals = system.Everyone
+
+kinto.bucket_create_principals = system.Everyone
+kinto.bucket_write_principals = system.Everyone
+kinto.bucket_read_principals = system.Everyone
+
+#
+# Kinto attachment
+#
+
+kinto.attachment.base_path = /tmp/attachments
+kinto.attachment.base_url =
+# See uwsgi static-map setting
+kinto.attachment.extra.base_url = http://localhost:8888/attachments
+kinto.attachment.folder = {bucket_id}/{collection_id}
+
+
+#
+# Kinto Remote Settings
+#
+
+kinto.changes.resources = /buckets/main
+
+kinto.signer.resources = /buckets/main-workspace -> /buckets/main-preview -> /buckets/main
+
+kinto.signer.to_review_enabled = false
+
+kinto.signer.auto_create_resources = true
+kinto.signer.auto_create_resources_principals = system.Everyone
+
+kinto.signer.signer_backend = kinto_remote_settings.signer.backends.local_ecdsa
+kinto.signer.ecdsa.private_key = /app/ecdsa.private.pem
+
+#
+# Simple daemon (see `run.sh start`)
+#
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 8888
+
+
+#
+# Performant daemon (see `run.sh uwsgistart`)
+#
+
+[uwsgi]
+wsgi-file = app.wsgi
+http-socket = 0.0.0.0:8888
+master = true
+module = kinto
+static-map = /attachments=/tmp/attachments
+
+
+#
+# Logging
+#
+
+[loggers]
+keys = root, kinto
+
+[handlers]
+keys = console
+
+[formatters]
+keys = color
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_kinto]
+level = DEBUG
+handlers = console
+qualname = kinto
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = color
+
+[formatter_color]
+class = logging_color_formatter.ColorFormatter

--- a/config/testing.ini
+++ b/config/testing.ini
@@ -77,7 +77,7 @@ port = 8888
 
 [uwsgi]
 wsgi-file = app.wsgi
-http-socket = 0.0.0.0:8888
+socket = /tmp/kinto.sock
 master = true
 module = kinto
 static-map = /attachments=/tmp/attachments

--- a/docs/tutorial-local-server.rst
+++ b/docs/tutorial-local-server.rst
@@ -26,8 +26,8 @@ There are several ways to run a local instance of Kinto, the underlying software
 We will use Docker for the sake of simplicity, but you may find more convenient to `install the Python package for example <http://kinto.readthedocs.io/en/stable/tutorials/install.html#using-the-python-package>`_.
 
 
-Quick start
------------
+Simple Mode (testing)
+---------------------
 
 We will run a local container with the minimal configuration. It should be enough to hack on your Remote Settings integration in the plane.
 However if your goal is to setup a local server that has the same signoff features as STAGE and PROD, you can continue into the configuration of the next section.

--- a/docs/tutorial-local-server.rst
+++ b/docs/tutorial-local-server.rst
@@ -66,7 +66,7 @@ With Multi-signoff (advanced)
 
 Using a different configuration, we can obtain a local instance that has proper authentication and multi-signoff that interacts with an `Autograph instance <https://github.com/mozilla-services/autograph/>`_ in order to sign the data, roughly like the STAGE server.
 
-We will run the Autograph container in a separate terminal. Since Autograph generates the ``x5u`` certificate chains on startup, we will use a volume mounted on the same location, so that Firefox can download them at the same location as the native ``x5u`` URLs.
+We will run the Autograph container in a separate terminal. Since Autograph generates the ``x5u`` certificate chains on startup, we will use a volume mounted on the same location, so that Firefox can download them at the same location as the native ``x5u`` URLs (Autograph will point ``x5u`` URLs to ``file:///tmp/attachments``).
 
 .. code-block:: bash
 

--- a/docs/tutorial-local-server.rst
+++ b/docs/tutorial-local-server.rst
@@ -103,7 +103,7 @@ Unlike with *Simple Mode*, we'll need an ``admin`` user:
 
 .. note::
 
-    Another option is to use ``docker-compose`` with a cloned repository of https://github.com/mozilla/remote-settings
+    Another option is to clone the `mozilla/remote-settings <https://github.com/mozilla/remote-settings>`_ repository and run ``make start``
 
 
 Prepare the client

--- a/docs/tutorial-local-server.rst
+++ b/docs/tutorial-local-server.rst
@@ -38,96 +38,6 @@ Pull the Docker container:
 
     docker pull mozilla/remote-settings
 
-Create a configuration file ``server.ini`` with the following content:
-
-.. code-block:: ini
-
-    [app:main]
-    use = egg:kinto
-    kinto.includes = kinto.plugins.admin
-                     kinto.plugins.accounts
-                     kinto.plugins.history
-                     kinto_changes
-                     kinto_attachment
-                     kinto_signer
-
-    kinto.storage_backend = kinto.core.storage.memory
-    kinto.storage_url =
-    kinto.cache_backend = kinto.core.cache.memory
-    kinto.cache_url =
-    kinto.permission_backend = kinto.core.permission.memory
-    kinto.permission_url =
-
-    multiauth.policies = account
-    multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
-    kinto.userid_hmac_secret = 284461170acd78f0be0827ef514754937474d7c922191e4f78be5c1d232b38c4
-
-    kinto.bucket_create_principals = system.Authenticated
-    kinto.account_create_principals = system.Everyone
-    kinto.account_write_principals = account:admin
-
-    kinto.experimental_permissions_endpoint = true
-    kinto.experimental_collection_schema_validation = true
-    kinto.changes.resources = /buckets/main
-    kinto.attachment.base_path = /tmp/attachments
-    kinto.attachment.base_url =
-    kinto.attachment.extra.base_url = http://localhost:8888/attachments
-    kinto.attachment.folder = {bucket_id}/{collection_id}
-    kinto.signer.resources = /buckets/main-workspace -> /buckets/main-preview -> /buckets/main
-    kinto.signer.group_check_enabled = true
-    kinto.signer.to_review_enabled = true
-    kinto.signer.signer_backend = kinto_signer.signer.autograph
-    kinto.signer.main-workspace.editors_group = {collection_id}-editors
-    kinto.signer.main-workspace.reviewers_group = {collection_id}-reviewers
-    kinto.signer.autograph.server_url = http://autograph-server:8000
-    # Use credentials from https://github.com/mozilla-services/autograph/blob/5b4a473/autograph.yaml
-    kinto.signer.autograph.hawk_id = kintodev
-    kinto.signer.autograph.hawk_secret = 3isey64n25fim18chqgewirm6z2gwva1mas0eu71e9jtisdwv6bd
-
-    [uwsgi]
-    wsgi-file = app.wsgi
-    enable-threads = true
-    http-socket = 0.0.0.0:8888
-    processes =  1
-    master = true
-    module = kinto
-    harakiri = 120
-    uid = kinto
-    gid = kinto
-    lazy = true
-    lazy-apps = true
-    single-interpreter = true
-    buffer-size = 65535
-    post-buffering = 65535
-    static-map = /attachments=/tmp/attachments
-
-    [loggers]
-    keys = root, kinto
-
-    [handlers]
-    keys = console
-
-    [formatters]
-    keys = color
-
-    [logger_root]
-    level = INFO
-    handlers = console
-
-    [logger_kinto]
-    level = DEBUG
-    handlers = console
-    qualname = kinto
-
-    [handler_console]
-    class = StreamHandler
-    args = (sys.stderr,)
-    level = NOTSET
-    formatter = color
-
-    [formatter_color]
-    class = logging_color_formatter.ColorFormatter
-
 Create a local folder to receive the potential records attachments, Docker should have the permissions to write it:
 
 .. code-block:: bash
@@ -138,80 +48,44 @@ Now, we will run the container with the local configuration file and attachments
 
 .. code-block:: bash
 
-    docker run -v `pwd`/server.ini:/etc/kinto.ini \
-               -v `pwd`/attachments:/tmp/attachments \
-               -e KINTO_INI=/etc/kinto.ini \
+    docker run -v `pwd`/attachments:/tmp/attachments \
+               -e KINTO_INI=config/testing.ini \
                -p 8888:8888 \
-               mozilla/remote-settings
+               mozilla/remote-settings \
+               uwsgistart
 
 Your local instance should now be running at http://localhost:8888/v1 and the Admin UI available at http://localhost:8888/v1/admin/
 
+With this configuration, this local server will roughly behave like the DEV server, but without authentication and with a dummy multi-signoff system.
 
-Create basic objects
-''''''''''''''''''''
+You can now jump to :ref:`the other tutorial <tutorial-dev-server>` in order to create remote records and synchronize locally.
 
-Let's create an ``admin`` user:
 
-.. code-block:: bash
+With Multi-signoff (advanced)
+-----------------------------
 
-    SERVER=http://localhost:8888/v1
+Using a different configuration, we can obtain a local instance that has proper authentication and multi-signoff that interacts with an `Autograph instance <https://github.com/mozilla-services/autograph/>`_ in order to sign the data, roughly like the STAGE server.
 
-    curl -X PUT ${SERVER}/accounts/admin \
-         -d '{"data": {"password": "s3cr3t"}}' \
-         -H 'Content-Type:application/json'
-
-And a ``main`` bucket, that is publicly readable and where authenticated users can create collections:
+We will run the Autograph container in a separate terminal. Since Autograph generates the ``x5u`` certificate chains on startup, we will use a volume mounted on the same location, so that Firefox can download them at the same location as the native ``x5u`` URLs.
 
 .. code-block:: bash
 
-    BASIC_AUTH=admin:s3cr3t
-
-    curl -X PUT ${SERVER}/buckets/main \
-         -d '{"permissions": {"read": ["system.Everyone"], "collection:create": ["system.Authenticated"]}}' \
-         -H 'Content-Type:application/json' \
-         -u $BASIC_AUTH
-
-Now your local server will roughly behave like the dev server, you can jump to :ref:`the other tutorial <tutorial-dev-server>` in order to create remote records and synchronize locally.
-
-
-Configure multi-signoff
------------------------
-
-In this section, we will have a local setup that enables multi-signoff and interacts with an `Autograph instance <https://github.com/mozilla-services/autograph/>`_ in order to sign the data.
-
-First, run the Autograph container in a separate terminal:
+    mkdir --mode=777 /tmp/attachments  # world writable
 
 .. code-block:: bash
 
-    docker run --rm --name autograph-server mozilla/autograph
-
-Autograph generates the ``x5u`` certificate chains on startup. In order to have them available to download from Firefox, let's copy them out of the container.
-
-First, look up the certificate filename using ``ls`` from within the container:
-
-.. code-block:: bash
-
-    docker exec -i -t autograph-server '/bin/sh'
-    $ ls /tmp/autograph/chains/remotesettingsdev/
-    remote-settings.content-signature.mozilla.org-20190503.chain
-    $ ^C
-
-Then, copy the file from the container into the host:
-
-.. code-block:: bash
-
-    mkdir -p /tmp/autograph/chains/remotesettingsdev/
-    docker cp autograph-server:/tmp/autograph/chains/remotesettingsdev/remote-settings.content-signature.mozilla.org-20190503.chain /tmp/autograph/chains/remotesettingsdev/
+    docker run -v /tmp/attachments:/tmp/attachments \
+               --rm --name autograph-server mozilla/autograph
 
 And run the Remote Settings server with a link to ``autograph-server`` container:
 
 .. code-block:: bash
 
-    docker run -v `pwd`/server.ini:/etc/kinto.ini \
-               --link autograph-server:autograph-server \
-               -e KINTO_INI=/etc/kinto.ini \
+    docker run --link autograph-server:autograph-server \
+               -e KINTO_INI=config/local.ini \
                -p 8888:8888 \
-               mozilla/remote-settings
+               mozilla/remote-settings \
+               uwsgistart
 
 Both containers should be connected, and the heartbeat endpoint should only return positive checks:
 
@@ -221,9 +95,7 @@ Both containers should be connected, and the heartbeat endpoint should only retu
 
     {"attachments":true, "cache":true, "permission":true, "signer": true, "storage":true}
 
-In the previous section we were using the ``main`` bucket directly, but in this setup, we will create the collections in the ``main-workspace`` bucket. Data will be automatically copied to the ``main-preview`` and ``main`` when requesting review and approving changes during the multi-signoff workflow.
-
-We'll use the same ``admin`` user:
+Unlike with *Simple Mode*, we'll need an ``admin`` user:
 
 .. code-block:: bash
 
@@ -231,30 +103,9 @@ We'll use the same ``admin`` user:
          -d '{"data": {"password": "s3cr3t"}}' \
          -H 'Content-Type:application/json'
 
-The ``main-workspace`` bucket allows any authenticated user to create collections (like on STAGE):
+.. note::
 
-.. code-block:: bash
-
-    BASIC_AUTH=admin:s3cr3t
-
-    curl -X PUT ${SERVER}/buckets/main-workspace \
-         -d '{"permissions": {"collection:create": ["system.Authenticated"], "group:create": ["system.Authenticated"]}}' \
-         -H 'Content-Type:application/json' \
-         -u $BASIC_AUTH
-
-The ``main-preview`` and ``main`` buckets are (re)initialized with read-only permissions:
-
-.. code-block:: bash
-
-    curl -X PUT ${SERVER}/buckets/main-preview \
-         -d '{"permissions": {"read": ["system.Everyone"]}}' \
-         -H 'Content-Type:application/json' \
-         -u $BASIC_AUTH
-
-    curl -X PUT ${SERVER}/buckets/main \
-         -d '{"permissions": {"read": ["system.Everyone"]}}' \
-         -H 'Content-Type:application/json' \
-         -u $BASIC_AUTH
+    Another option is to use ``docker-compose`` with a cloned repository of https://github.com/mozilla/remote-settings
 
 
 Prepare the client

--- a/docs/tutorial-local-server.rst
+++ b/docs/tutorial-local-server.rst
@@ -51,8 +51,7 @@ Now, we will run the container with the local configuration file and attachments
     docker run -v `pwd`/attachments:/tmp/attachments \
                -e KINTO_INI=config/testing.ini \
                -p 8888:8888 \
-               mozilla/remote-settings \
-               uwsgistart
+               mozilla/remote-settings
 
 Your local instance should now be running at http://localhost:8888/v1 and the Admin UI available at http://localhost:8888/v1/admin/
 
@@ -84,8 +83,7 @@ And run the Remote Settings server with a link to ``autograph-server`` container
     docker run --link autograph-server:autograph-server \
                -e KINTO_INI=config/local.ini \
                -p 8888:8888 \
-               mozilla/remote-settings \
-               uwsgistart
+               mozilla/remote-settings
 
 Both containers should be connected, and the heartbeat endpoint should only return positive checks:
 

--- a/kinto-remote-settings/src/kinto_remote_settings/signer/generate_keypair.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/signer/generate_keypair.py
@@ -15,6 +15,9 @@ def generate_keypair(private_key_location, public_key_location):
 
 if __name__ == "__main__":  # pragma: no cover
     if len(sys.argv) != 3:
-        print("Usage: python -m signer.generate_keypair " "{public_key} {private_key}")
+        print(
+            "Usage: python -m kinto_remote_settings.signer.generate_keypair "
+            "{private_key} {public_key}"
+        )
         sys.exit(0)
     generate_keypair(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
Fixes #151 

* [x] figure out why uwsgistart complains about port
* [x] Read `KINTO_SIGNER_RESOURCES` from env, to be able to have the server auto create a specific collection on startup --> #156 
* [ ] Proof read tutorial