### PR TITLE
Only run build_and_publish on main branch or git tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,4 +162,7 @@ workflows:
             - integration_test
           filters:
             tags:
-              only: /.*/
+              only: /.+/
+            branches:
+              only: main
+              


### PR DESCRIPTION
Based on the filters set for `build_and_publish`, prior to this commit,
I would have expected this job to only run on tagged commits. However,
this job seemed to run on every commit, leading me to beleive the regex
provided would match an empty tag. So, the regex was changed to match a
non-empty string.

Additionaly, a filter was added so that the build_and_publish job will
only run on the "main" branch. After this commit is merged, we expect
this job to run on tagged commits or after any commit to the "main"
branch.