### PR TITLE
Prepare running integration tests on remote server (ref #152)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,26 @@ finished, run:
 
     make stop
 
+
+Test Remote Server
+------------------
+
+Integration tests can be executed on a remote server.
+
+.. code-block:: shell
+
+    docker-compose build tests
+
+.. code-block:: shell
+
+    docker-compose run remotesettings:tests \
+        -e SERVER=http://settings.dev.mozaws.net \
+        -e MAIL_DIR="" \
+        -e SKIP_SERVER_SETUP=true \
+        -e EDITOR_AUTH=editor:azerty123" \
+        -e REVIEWER_AUTH=reviwer:s3cr3t"
+
+
 Debugging Locally (simple)
 --------------------------
 

--- a/config/example.ini
+++ b/config/example.ini
@@ -167,6 +167,7 @@ kinto.signer.autograph.hawk_secret = 3isey64n25fim18chqgewirm6z2gwva1mas0eu71e9j
 #
 mail.default_sender = kinto@restmail.net
 mail.debug_mailer = true
+mail.queue_path = mail/
 # mail.host = localhost
 # mail.port = 25
 # mail.username = None
@@ -175,7 +176,6 @@ mail.debug_mailer = true
 # mail.ssl = False
 # mail.keyfile = None
 # mail.certfile = None
-# mail.queue_path = None
 # mail.debug = 0
 # mail.sendmail_app = /usr/sbin/sendmail
 # mail.sendmail_template = {sendmail_app} -t -i -f {sender}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ DEFAULT_EDITOR_AUTH = os.getenv("EDITOR_AUTH", "editor:pass")
 DEFAULT_REVIEWER_AUTH = os.getenv("REVIEWER_AUTH", "reviewer:pass")
 DEFAULT_BUCKET = os.getenv("BUCKET", "main-workspace")
 DEFAULT_COLLECTION = os.getenv("COLLECTION", "product-integrity")
+DEFAULT_MAIL_DIR = os.getenv("MAIL_DIR", "mail")
 DEFAULT_KEEP_EXISTING = asbool(os.getenv("KEEP_EXISTING", False))
 DEFAULT_SKIP_SERVER_SETUP = asbool(os.getenv("SKIP_SERVER_SETUP", False))
 
@@ -63,6 +64,12 @@ def pytest_addoption(parser):
         help="Source collection",
     )
     parser.addoption(
+        "--mail-dir",
+        action="store",
+        default=DEFAULT_MAIL_DIR,
+        help="Directory of debug email files (from server)",
+    )
+    parser.addoption(
         "--keep-existing",
         action="store_true",
         default=DEFAULT_KEEP_EXISTING,
@@ -104,6 +111,11 @@ def source_bucket(request) -> str:
 @pytest.fixture(scope="session")
 def source_collection(request) -> str:
     return request.config.getoption("--collection")
+
+
+@pytest.fixture(scope="session")
+def mail_dir(request) -> str:
+    return request.config.getoption("--mail-dir")
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
+import os
 from typing import Callable, Tuple
 
 import pytest
 import requests
+from pyramid.settings import asbool
 from kinto_http import AsyncClient, KintoException
 from pytest import FixtureRequest
 from requests.adapters import HTTPAdapter
@@ -10,12 +12,13 @@ from selenium.webdriver.remote.webdriver import WebDriver
 from urllib3.util.retry import Retry
 
 
-DEFAULT_SERVER = "http://localhost:8888/v1"
-DEFAULT_SETUP_AUTH = "user:pass"
-DEFAULT_EDITOR_AUTH = "editor:pass"
-DEFAULT_REVIEWER_AUTH = "reviewer:pass"
-DEFAULT_BUCKET = "main-workspace"
-DEFAULT_COLLECTION = "product-integrity"
+DEFAULT_SERVER = os.getenv("SERVER", "http://localhost:8888/v1")
+DEFAULT_SETUP_AUTH = os.getenv("SETUP_AUTH", "user:pass")
+DEFAULT_EDITOR_AUTH = os.getenv("EDITOR_AUTH", "editor:pass")
+DEFAULT_REVIEWER_AUTH = os.getenv("REVIEWER_AUTH", "reviewer:pass")
+DEFAULT_BUCKET = os.getenv("BUCKET", "main-workspace")
+DEFAULT_COLLECTION = os.getenv("COLLECTION", "product-integrity")
+DEFAULT_KEEP_EXISTING = asbool(os.getenv("KEEP_EXISTING", False))
 
 Auth = Tuple[str, str]
 ClientFactory = Callable[[Auth], AsyncClient]
@@ -61,7 +64,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--keep-existing",
         action="store_true",
-        default=False,
+        default=DEFAULT_KEEP_EXISTING,
         help="Keep existing collection data",
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,15 +169,15 @@ def make_client(
 @pytest.fixture(autouse=True)
 async def flush_default_collection(
     make_client: ClientFactory,
-    auth: Auth,
+    setup_auth: Auth,
     source_bucket: str,
     source_collection: str,
 ):
     yield
-    client = make_client(auth)
+    setup_client = make_client(setup_auth)
 
     try:
-        await client.delete_collection(
+        await setup_client.delete_collection(
             id=source_collection, bucket=source_bucket, if_exists=True
         )
     except KintoException as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from urllib3.util.retry import Retry
 
 
 DEFAULT_SERVER = "http://localhost:8888/v1"
-DEFAULT_AUTH = "user:pass"
+DEFAULT_SETUP_AUTH = "user:pass"
 DEFAULT_EDITOR_AUTH = "editor:pass"
 DEFAULT_REVIEWER_AUTH = "reviewer:pass"
 DEFAULT_BUCKET = "main-workspace"
@@ -29,10 +29,10 @@ def pytest_addoption(parser):
         help="Kinto server (in form 'http(s)://<host>:<port>/v1')",
     )
     parser.addoption(
-        "--auth",
+        "--setup-auth",
         action="store",
-        default=DEFAULT_AUTH,
-        help="Basic authentication",
+        default=DEFAULT_SETUP_AUTH,
+        help="Basic authentication for server setup",
     )
     parser.addoption(
         "--editor-auth",
@@ -72,8 +72,8 @@ def server(request) -> str:
 
 
 @pytest.fixture(scope="session")
-def auth(request) -> Auth:
-    return tuple(request.config.getoption("--auth").split(":"))
+def setup_auth(request) -> Auth:
+    return tuple(request.config.getoption("--setup-auth").split(":"))
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -89,12 +89,17 @@ async def test_email_plugin(
     make_client: ClientFactory,
     setup_auth: Auth,
     editor_auth: Auth,
+    mail_dir: str,
     skip_server_setup: bool,
 ):
+    if not mail_dir:
+        # Skip test if mail dir is empty (eg. testing remote server)
+        return
+
     # remove any existing .eml files in mail directory
     try:
-        for file in os.listdir("mail"):
-            os.remove(f"mail/{file}")
+        for file in os.listdir(mail_dir):
+            os.remove(f"{mail_dir}/{file}")
     except FileNotFoundError:
         pass
 
@@ -133,7 +138,7 @@ async def test_email_plugin(
         id="product-integrity", bucket="main-workspace", data={"status": "to-review"}
     )
 
-    mail = os.listdir("mail")
+    mail = os.listdir(mail_dir)
     assert mail, "No emails created"
     assert len(mail) == 1
     assert mail[0].endswith(".eml")

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -19,20 +19,26 @@ def test_heartbeat(server: str):
     resp.raise_for_status()
 
 
-async def test_history_plugin(make_client: ClientFactory, auth: Auth):
-    client = make_client(auth)
-    client_id = (await client.server_info())["user"]["id"]
-    await client.create_bucket(id="main-workspace", if_not_exists=True)
-    await client.purge_history(bucket="main-workspace")
-    await client.create_collection(
+async def test_history_plugin(
+    make_client: ClientFactory, setup_auth: Auth, editor_auth: Auth, keep_existing: bool
+):
+    setup_client = make_client(setup_auth)
+    await setup_client.create_bucket(id="main-workspace", if_not_exists=True)
+    if not keep_existing:
+        await setup_client.purge_history(bucket="main-workspace")
+    await setup_client.create_collection(
         id="product-integrity", bucket="main-workspace", if_not_exists=True
     )
-    data = JSONPatch([{"op": "add", "path": "/data/members/0", "value": client_id}])
-    await client.patch_group(id="product-integrity-editors", changes=data)
-    await client.create_record(data={"hola": "mundo"})
-    await client.patch_collection(data={"status": "to-review"})
 
-    history = await client.get_history(bucket="main-workspace")
+    editor_client = make_client(editor_auth)
+    editor_id = (await editor_client.server_info())["user"]["id"]
+    data = JSONPatch([{"op": "add", "path": "/data/members/0", "value": editor_id}])
+    await client.patch_group(id="product-integrity-editors", changes=data)
+
+    await editor_client.create_record(data={"hola": "mundo"})
+    await editor_client.patch_collection(data={"status": "to-review"})
+
+    history = await editor_client.get_history(bucket="main-workspace")
 
     history.reverse()
     collection_entries = [
@@ -41,7 +47,8 @@ async def test_history_plugin(make_client: ClientFactory, auth: Auth):
         if e["resource_name"] == "collection"
         and e["collection_id"] == "product-integrity"
     ]
-    assert len(collection_entries) == 5
+    if not keep_existing:
+        assert len(collection_entries) == 5
 
     (
         event_creation,
@@ -49,7 +56,7 @@ async def test_history_plugin(make_client: ClientFactory, auth: Auth):
         event_wip,
         event_to_review,
         event_review_attrs,
-    ) = collection_entries
+    ) = collection_entries[:5]
 
     assert event_creation["action"] == "create"
     assert event_creation["user_id"] == "account:user"
@@ -73,7 +80,9 @@ async def test_history_plugin(make_client: ClientFactory, auth: Auth):
     )
 
 
-async def test_email_plugin(make_client: ClientFactory, auth: Auth):
+async def test_email_plugin(
+    make_client: ClientFactory, setup_auth: Auth, editor_auth: Auth
+):
     # remove any existing .eml files in mail directory
     try:
         for file in os.listdir("mail"):
@@ -81,12 +90,12 @@ async def test_email_plugin(make_client: ClientFactory, auth: Auth):
     except FileNotFoundError:
         pass
 
-    client = make_client(auth)
-    await client.create_bucket(id="main-workspace", if_not_exists=True)
-    await client.create_collection(
+    setup_client = make_client(setup_auth)
+    await setup_client.create_bucket(id="main-workspace", if_not_exists=True)
+    await setup_client.create_collection(
         id="product-integrity", bucket="main-workspace", if_not_exists=True
     )
-    await client.patch_bucket(
+    await setup_client.patch_bucket(
         id="main-workspace",
         data={
             "kinto-emailer": {
@@ -104,7 +113,9 @@ async def test_email_plugin(make_client: ClientFactory, auth: Auth):
             }
         },
     )
-    await client.patch_collection(
+
+    editor_client = make_client(editor_auth)
+    await editor_client.patch_collection(
         id="product-integrity", bucket="main-workspace", data={"status": "to-review"}
     )
 
@@ -120,24 +131,23 @@ async def test_email_plugin(make_client: ClientFactory, auth: Auth):
 
 
 async def test_attachment_plugin_new_record(
-    make_client: ClientFactory,
-    auth: Auth,
-    server: str,
+    make_client: ClientFactory, setup_auth: Auth, editor_auth: Auth
 ):
-    client = make_client(auth)
-    await client.create_bucket(id="main-workspace", if_not_exists=True)
-    await client.create_collection(
+    setup_client = make_client(setup_auth)
+    await setup_client.create_bucket(id="main-workspace", if_not_exists=True)
+    await setup_client.create_collection(
         id="product-integrity", bucket="main-workspace", if_not_exists=True
     )
 
+    editor_client = make_client(editor_auth)
     with open("kinto-logo.svg", "rb") as attachment:
         assert requests.post(
-            f"{server}{await client.get_endpoint('record', bucket='main-workspace', collection='product-integrity', id='logo')}/attachment",
+            f"{editor_client.session.server_url}{await editor_client.get_endpoint('record', bucket='main-workspace', collection='product-integrity', id='logo')}/attachment",
             files={"attachment": attachment},
-            auth=client.session.auth,
+            auth=editor_client.session.auth,
         ), "Issue creating a new record with an attachment"
 
-    record = await client.get_record(
+    record = await editor_client.get_record(
         id="logo", bucket="main-workspace", collection="product-integrity"
     )
 
@@ -147,16 +157,15 @@ async def test_attachment_plugin_new_record(
 
 
 async def test_attachment_plugin_existing_record(
-    make_client: ClientFactory,
-    auth: Auth,
-    server: str,
+    make_client: ClientFactory, setup_auth: Auth, editor_auth: Auth
 ):
-    client = make_client(auth)
-    await client.create_bucket(id="main-workspace", if_not_exists=True)
-    await client.create_collection(
+    setup_client = make_client(setup_auth)
+    await setup_client.create_bucket(id="main-workspace", if_not_exists=True)
+    await setup_client.create_collection(
         id="product-integrity", bucket="main-workspace", if_not_exists=True
     )
-    await client.create_record(
+    editor_client = make_client(editor_auth)
+    await editor_client.create_record(
         id="logo",
         bucket="main-workspace",
         collection="product-integrity",
@@ -166,12 +175,12 @@ async def test_attachment_plugin_existing_record(
 
     with open("kinto-logo.svg", "rb") as attachment:
         assert requests.post(
-            f"{server}{await client.get_endpoint('record', bucket='main-workspace', collection='product-integrity', id='logo')}/attachment",
+            f"{editor_client.session.server_url}{await editor_client.get_endpoint('record', bucket='main-workspace', collection='product-integrity', id='logo')}/attachment",
             files={"attachment": attachment},
-            auth=client.session.auth,
+            auth=editor_client.session.auth,
         ), "Issue updating an existing record to include an attachment"
 
-    record = await client.get_record(
+    record = await editor_client.get_record(
         id="logo", bucket="main-workspace", collection="product-integrity"
     )
 
@@ -180,16 +189,16 @@ async def test_attachment_plugin_existing_record(
     assert "attachment" in record["data"]
 
 
-async def test_signer_plugin_capabilities(make_client: ClientFactory, auth: Auth):
-    client = make_client(auth)
-    capability = (await client.server_info())["capabilities"]["signer"]
+async def test_signer_plugin_capabilities(make_client: ClientFactory):
+    anonymous_client = make_client(":")
+    capability = (await anonymous_client.server_info())["capabilities"]["signer"]
     assert capability["group_check_enabled"]
     assert capability["to_review_enabled"]
 
 
 async def test_signer_plugin_full_workflow(
     make_client: ClientFactory,
-    auth: Auth,
+    setup_auth: Auth,
     editor_auth: Auth,
     reviewer_auth: Auth,
     server: str,
@@ -197,12 +206,12 @@ async def test_signer_plugin_full_workflow(
     source_collection: str,
     keep_existing: bool,
 ):
-    client = make_client(auth)
+    setup_client = make_client(setup_auth)
     editor_client = make_client(editor_auth)
     reviewer_client = make_client(reviewer_auth)
 
     # 0. initialize source bucket/collection (if necessary)
-    server_info = await client.server_info()
+    server_info = await setup_client.server_info()
     editor_id = (await editor_client.server_info())["user"]["id"]
     reviewer_id = (await reviewer_client.server_info())["user"]["id"]
 
@@ -219,11 +228,15 @@ async def test_signer_plugin_full_workflow(
     assert resources, "Specified source not configured to be signed"
     resource = resources[0]
 
-    await client.create_bucket(if_not_exists=True)
-    await client.create_bucket(id=resource["preview"]["bucket"], if_not_exists=True)
-    await client.create_bucket(id=resource["destination"]["bucket"], if_not_exists=True)
+    await setup_client.create_bucket(if_not_exists=True)
+    await setup_client.create_bucket(
+        id=resource["preview"]["bucket"], if_not_exists=True
+    )
+    await setup_client.create_bucket(
+        id=resource["destination"]["bucket"], if_not_exists=True
+    )
 
-    await client.create_collection(
+    await setup_client.create_collection(
         permissions={"write": [editor_id, reviewer_id]},
         if_not_exists=True,
     )
@@ -233,14 +246,14 @@ async def test_signer_plugin_full_workflow(
     )
     editors_group = editors_group.format(collection_id=source_collection)
     data = JSONPatch([{"op": "add", "path": "/data/members/0", "value": editor_id}])
-    await client.patch_group(id=editors_group, changes=data)
+    await setup_client.patch_group(id=editors_group, changes=data)
 
     reviewers_group = (
         resource.get("reviewers_group") or signer_capabilities["reviewers_group"]
     )
     reviewers_group = reviewers_group.format(collection_id=source_collection)
     data = JSONPatch([{"op": "add", "path": "/data/members/0", "value": reviewer_id}])
-    await client.patch_group(id=reviewers_group, changes=data)
+    await setup_client.patch_group(id=reviewers_group, changes=data)
 
     dest_col = resource["destination"].get("collection") or source_collection
     dest_client = AsyncClient(
@@ -257,10 +270,10 @@ async def test_signer_plugin_full_workflow(
         collection=preview_collection,
     )
 
-    existing_records = await client.get_records()
+    existing_records = await editor_client.get_records()
     existing = len(existing_records)
     if existing > 0 and not keep_existing:
-        await client.delete_records()
+        await editor_client.delete_records()
         existing = 0
 
         # Status is now WIP.
@@ -275,7 +288,7 @@ async def test_signer_plugin_full_workflow(
         await verify_signature([], timestamp, signature)
 
     # 1. upload data
-    records = await upload_records(client, 20)
+    records = await upload_records(editor_client, 20)
 
     # 2. ask for a signature
     # 2.1 ask for review
@@ -299,13 +312,13 @@ async def test_signer_plugin_full_workflow(
     await reviewer_client.patch_collection(data=data)
 
     # 3. upload more data
-    await upload_records(client, 20)
+    await upload_records(editor_client, 20)
 
     for toupdate in random.sample(records, 5):
         await editor_client.patch_record(data=dict(newkey=_rand(10), **toupdate))
 
     for todelete in random.sample(records, 5):
-        await client.delete_record(id=todelete["id"])
+        await editor_client.delete_record(id=todelete["id"])
 
     expected = existing + 20 + 20 - 5
 
@@ -346,48 +359,59 @@ async def test_signer_plugin_full_workflow(
         raise
 
 
-async def test_signer_plugin_rollback(make_client: ClientFactory, auth: Auth):
-    client = make_client(auth)
-    await client.create_bucket(id="main-workspace", if_not_exists=True)
-    await client.create_collection(
+async def test_signer_plugin_rollback(
+    make_client: ClientFactory, setup_auth: Auth, editor_auth: Auth
+):
+    setup_client = make_client(setup_auth)
+    await setup_client.create_bucket(id="main-workspace", if_not_exists=True)
+    await setup_client.create_collection(
         id="product-integrity", bucket="main-workspace", if_not_exists=True
     )
+
+    editor_client = make_client(editor_auth)
     before_records = await client.get_records()
 
-    await upload_records(client, 5)
+    await upload_records(editor_client, 5)
 
-    records = await client.get_records()
+    records = await editor_client.get_records()
     assert len(records) == len(before_records) + 5
-    await client.patch_collection(data={"status": "to-rollback"})
-    records = await client.get_records()
+    await editor_client.patch_collection(data={"status": "to-rollback"})
+    records = await editor_client.get_records()
     assert len(records) == len(before_records)
 
 
 async def test_signer_plugin_refresh(
     make_client: ClientFactory,
-    auth: Auth,
+    setup_auth: Auth,
+    editor_auth: Auth,
     reviewer_auth: Auth,
 ):
     cid = "product-integrity"
-    client = make_client(auth)
+    setup_client = make_client(setup_auth)
     reviewer_client = make_client(reviewer_auth)
     reviewer_id = (await reviewer_client.server_info())["user"]["id"]
-    await client.create_bucket(id="main-workspace", if_not_exists=True)
-    await client.create_collection(id=cid, bucket="main-workspace", if_not_exists=True)
+    await setup_client.create_bucket(id="main-workspace", if_not_exists=True)
+    await setup_client.create_collection(
+        id=cid, bucket="main-workspace", if_not_exists=True
+    )
     data = JSONPatch([{"op": "add", "path": "/data/members/0", "value": reviewer_id}])
-    await client.patch_group(id="product-integrity-reviewers", changes=data)
-    await upload_records(client, 5)
-    await client.patch_collection(data={"status": "to-review"})
+    await setup_client.patch_group(id="product-integrity-reviewers", changes=data)
+
+    editor_client = make_client(editor_auth)
+    await upload_records(editor_client, 5)
+    await editor_auth.patch_collection(data={"status": "to-review"})
     await reviewer_client.patch_collection(id=cid, data={"status": "to-sign"})
-    signature_preview_before = (await client.get_collection(bucket="main-preview"))[
-        "data"
-    ]["signature"]
-    signature_before = (await client.get_collection(bucket="main"))["data"]["signature"]
+    signature_preview_before = (
+        await editor_client.get_collection(bucket="main-preview")
+    )["data"]["signature"]
+    signature_before = (await editor_client.get_collection(bucket="main"))["data"][
+        "signature"
+    ]
 
     await reviewer_client.patch_collection(id=cid, data={"status": "to-resign"})
 
-    signature = (await client.get_collection(bucket="main"))["data"]["signature"]
-    signature_preview = (await client.get_collection(bucket="main"))["data"][
+    signature = (await editor_client.get_collection(bucket="main"))["data"]["signature"]
+    signature_preview = (await editor_client.get_collection(bucket="main"))["data"][
         "signature"
     ]
 
@@ -397,24 +421,26 @@ async def test_signer_plugin_refresh(
 
 async def test_signer_plugin_reviewer_verifications(
     make_client: ClientFactory,
-    auth: Auth,
+    setup_auth: Auth,
+    editor_auth: Auth,
     reviewer_auth: Auth,
 ):
-    client = make_client(auth)
-    client_id = (await client.server_info())["user"]["id"]
+    editor_client = make_client(editor_auth)
+    editor_id = (await editor_client.server_info())["user"]["id"]
     reviewer_client = make_client(reviewer_auth)
     reviewer_id = (await reviewer_client.server_info())["user"]["id"]
-    await client.create_bucket(id="main-workspace", if_not_exists=True)
-    await client.create_collection(
+    setup_client = make_client(setup_auth)
+    await setup_client.create_bucket(id="main-workspace", if_not_exists=True)
+    await setup_client.create_collection(
         id="product-integrity", bucket="main-workspace", if_not_exists=True
     )
-    await client.patch_group(
-        id="product-integrity-editors", data={"members": [client_id]}
+    await setup_client.patch_group(
+        id="product-integrity-editors", data={"members": [editor_id]}
     )
-    await client.patch_group(
-        id="product-integrity-reviewers", data={"members": [client_id, reviewer_id]}
+    await setup_client.patch_group(
+        id="product-integrity-reviewers", data={"members": [editor_id, reviewer_id]}
     )
-    await upload_records(client, 5)
+    await upload_records(editor_client, 5)
 
     # status cannot be set to to-sign
     with pytest.raises(KintoException):
@@ -425,7 +451,7 @@ async def test_signer_plugin_reviewer_verifications(
         await reviewer_client.patch_collection(data={"status": "to-review"})
 
     # Add reviewer to editors
-    await client.patch_group(
+    await setup_client.patch_group(
         id="product-integrity-editors", data={"members": [reviewer_id]}
     )
     await reviewer_client.patch_collection(data={"status": "to-review"})
@@ -434,14 +460,14 @@ async def test_signer_plugin_reviewer_verifications(
         await reviewer_client.patch_collection(data={"status": "to-sign"})
 
     # review must be asked after cancelled
-    await client.patch_collection(data={"status": "to-review"})
+    await editor_client.patch_collection(data={"status": "to-review"})
     await reviewer_client.patch_collection(data={"status": "work-in-progress"})
     with pytest.raises(KintoException):
         await reviewer_client.patch_collection(data={"status": "to-sign"})
 
     await reviewer_client.patch_collection(data={"status": "to-review"})
     # Client can now review because he is not the last_editor.
-    await client.patch_collection(data={"status": "to-sign"})
+    await editor_client.patch_collection(data={"status": "to-sign"})
 
 
 class FakeRootHash:
@@ -458,13 +484,17 @@ async def verify_signature(records, timestamp, signature):
         await verifier.verify(serialized, signature["signature"], x5u)
 
 
-async def test_changes_plugin(make_client: ClientFactory, auth: Auth):
-    client = make_client(auth)
-    await client.create_bucket(id="main-workspace", if_not_exists=True)
-    await client.create_collection(
+async def test_changes_plugin(
+    make_client: ClientFactory, setup_auth: Auth, editor_auth: Auth
+):
+    setup_client = make_client(setup_auth)
+    await setup_client.create_bucket(id="main-workspace", if_not_exists=True)
+    await setup_client.create_collection(
         id="product-integrity", bucket="main-workspace", if_not_exists=True
     )
-    records = await client.get_records(bucket="monitor", collection="changes")
+
+    anonymous_client = make_client(":")
+    records = await anonymous_client.get_records(bucket="monitor", collection="changes")
 
     assert records
     assert len(records) == 1
@@ -473,8 +503,10 @@ async def test_changes_plugin(make_client: ClientFactory, auth: Auth):
 
     initial_last_modified = records[0]["last_modified"]
 
-    await upload_records(client, 10, "main-workspace", "product-integrity")
-    records = await client.get_records(bucket="monitor", collection="changes")
+    editor_client = make_client(editor_auth)
+    await upload_records(editor_client, 10, "main-workspace", "product-integrity")
+
+    records = await anonymous_client.get_records(bucket="monitor", collection="changes")
 
     updated_last_modified = records[0]["last_modified"]
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -15,6 +15,7 @@ usage() {
 
 case $1 in
 start)
+    shift
     wget -q --tries=180 --retry-connrefused --waitretry=1 -O /dev/null $SERVER || (echo "Can't reach $SERVER" && exit 1)
     http -q --check-status $SERVER/__heartbeat__
     pytest integration_test.py $@

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -17,7 +17,7 @@ case $1 in
 start)
     wget -q --tries=180 --retry-connrefused --waitretry=1 -O /dev/null $SERVER || (echo "Can't reach $SERVER" && exit 1)
     http -q --check-status $SERVER/__heartbeat__
-    pytest integration_test.py --server $SERVER
+    pytest integration_test.py $@
     pytest --driver Remote --capability browserName firefox --base-url $SERVER/admin --verify-base-url browser_test.py --server $SERVER
     ;;
 *)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-: "${SERVER:=http://web:8888/v1}"
+: "${SERVER:=http://localhost:8888/v1}"
 
 usage() {
     echo "usage: ./run.sh start"


### PR DESCRIPTION
ref #152

The goal here is to be able to run the integration tests container against a remote server. 
I added the option the skip server setup so that we can run the script without providing any admin credentials. Indeed, the `create_if_exists` behaviour works well when the provided user has creation permissions, otherwise the call to create() methods just raises 403s. By skipping setup, we allow the script to run with just editor and reviewers credentials (useful for STAGE)

Reviewing individual commits should be easier :) 