### PR TITLE
Do not build test container from the server one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 RUN uwsgi --build-plugin https://github.com/Datadog/uwsgi-dogstatsd
 
 
-FROM python:3.9-slim-bullseye@sha256:daf74cd7c4a6d420c2979b1fc74a3000489b69a330cbc15d0ab7b4721697945a AS build
+FROM python:3.9-slim-bullseye@sha256:daf74cd7c4a6d420c2979b1fc74a3000489b69a330cbc15d0ab7b4721697945a AS server
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # Needed for UWSGI 

--- a/Dockerfile.Testing
+++ b/Dockerfile.Testing
@@ -1,8 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-# This name comes from the docker-compose yml file that defines a name
-# for the "web" container's image.
-FROM remotesettings:build
+FROM python:3.9-slim-bullseye@sha256:daf74cd7c4a6d420c2979b1fc74a3000489b69a330cbc15d0ab7b4721697945a AS tests
 
 WORKDIR /app
 
@@ -20,6 +18,5 @@ COPY requirements-dev.txt .
 RUN pip install --no-cache-dir -r requirements-dev.txt
 
 COPY tests .
-COPY kinto-remote-settings/tests ./kinto-remote-settings/tests
 
 ENTRYPOINT ["/bin/bash", "/app/run.sh"]

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ integration-test:
 	docker-compose run tests
 
 build:
-	docker build . -t remotesettings:build
+	docker build . -t remotesettings:server
 	docker build . --file Dockerfile.Testing -t remotesettings:tests
 	docker-compose build
 

--- a/bin/deploy-dockerhub.sh
+++ b/bin/deploy-dockerhub.sh
@@ -30,7 +30,7 @@ docker images
 if [ -n "$1" ]; then
     TAG="$1"
     echo "Tag and push ${DOCKERHUB_REPO}:${TAG} to Dockerhub"
-    docker tag remotesettings:build "$DOCKERHUB_REPO:$TAG" ||
+    docker tag remotesettings:server "$DOCKERHUB_REPO:$TAG" ||
         (echo "Couldn't tag remote-settings as $DOCKERHUB_REPO:$TAG" && false)
     retry 3 docker push "$DOCKERHUB_REPO:$TAG" ||
         (echo "Couldn't push $DOCKERHUB_REPO:$TAG" && false)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.Testing
-    image: kinto:tests
+    image: remotesettings:tests
     depends_on:
       - web
       - selenium
@@ -73,6 +73,4 @@ services:
     volumes:
       - $PWD/tests:/app
       - $PWD/mail:/app/mail/
-      - $PWD/kinto-remote-settings:/app/kinto-remote-settings
-      - $PWD/setup.cfg:/app/setup.cfg
-    command: start
+    command: tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: remotesettings:build
+    image: remotesettings:server
     depends_on:
       - db
       - memcached

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 aiohttp
 autograph-utils
 black
+canonicaljson
 flake8
 httpie
 isort

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,15 @@ from typing import Callable, Tuple
 import pytest
 import requests
 from kinto_http import AsyncClient, KintoException
-from pyramid.settings import asbool
 from pytest import FixtureRequest
 from requests.adapters import HTTPAdapter
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.remote.webdriver import WebDriver
 from urllib3.util.retry import Retry
+
+
+def asbool(s):
+    return s.strip().lower() in ("true", "yes", "on", "1")
 
 
 DEFAULT_SERVER = os.getenv("SERVER", "http://localhost:8888/v1")
@@ -19,8 +22,8 @@ DEFAULT_REVIEWER_AUTH = os.getenv("REVIEWER_AUTH", "reviewer:pass")
 DEFAULT_BUCKET = os.getenv("BUCKET", "main-workspace")
 DEFAULT_COLLECTION = os.getenv("COLLECTION", "product-integrity")
 DEFAULT_MAIL_DIR = os.getenv("MAIL_DIR", "mail")
-DEFAULT_KEEP_EXISTING = asbool(os.getenv("KEEP_EXISTING", False))
-DEFAULT_SKIP_SERVER_SETUP = asbool(os.getenv("SKIP_SERVER_SETUP", False))
+DEFAULT_KEEP_EXISTING = asbool(os.getenv("KEEP_EXISTING", "false"))
+DEFAULT_SKIP_SERVER_SETUP = asbool(os.getenv("SKIP_SERVER_SETUP", "false"))
 
 Auth = Tuple[str, str]
 ClientFactory = Callable[[Auth], AsyncClient]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,9 +4,9 @@ set -eo pipefail
 : "${SERVER:=http://web:8888/v1}"
 
 usage() {
-    echo "usage: ./run.sh start"
+    echo "usage: ./run.sh tests"
     echo ""
-    echo "    start                         Start tests"
+    echo "    tests                         Start tests"
     echo ""
     exit 1
 }
@@ -14,7 +14,7 @@ usage() {
 [ $# -lt 1 ] && usage
 
 case $1 in
-start)
+tests)
     wget -q --tries=180 --retry-connrefused --waitretry=1 -O /dev/null $SERVER || (echo "Can't reach $SERVER" && exit 1)
     http -q --check-status $SERVER/__heartbeat__
     pytest integration_test.py --server $SERVER


### PR DESCRIPTION
I don't see why the integration tests would have to inherit from the server container, and I changed it to be built from a simple python container. Less confusing IMO

If it wasn't for Selenium, the integration tests could almost even run outside docker-compose, as a plain python script.

