### PR TITLE
Fix skipped integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,9 @@ target/
 .python_history
 
 # misc
+autograph-certs/chains
 tests/pub
-tests/setup.cfg
+tests/pyproject.toml
 mail/*.eml
 attachments/
 .DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,4 +73,5 @@ services:
     volumes:
       - $PWD/tests:/app
       - $PWD/mail:/app/mail/
+      - $PWD/pyproject.toml:/app/pyproject.toml
     command: tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,8 +70,9 @@ services:
       - SERVER=http://web:8888/v1
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
+      - MAIL_DIR=/var/debug-mail/
     volumes:
       - $PWD/tests:/app
-      - $PWD/mail:/app/mail/
+      - $PWD/mail:/var/debug-mail/
       - $PWD/pyproject.toml:/app/pyproject.toml
     command: tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ src_paths = ["kinto-remote-settings", "tests"]
 # --tb=native: traceback printing with Python standard library formatting
 addopts = "-ra --showlocals --tb=native"
 sensitive_url = "https://settings-writer.prod.mozaws.net/v1/admin"
-asyncio_mode = "auto"
+asyncio_mode = "strict"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 aiohttp
 autograph-utils
 black
-canonicaljson
+canonicaljson-rs
 flake8
 httpie
 isort

--- a/tests/browser_test.py
+++ b/tests/browser_test.py
@@ -19,6 +19,7 @@ async def test_review_signoff(
     editor_auth: Auth,
     reviewer_auth: Auth,
     skip_server_setup: bool,
+    keep_existing: bool,
 ):
     editor_client = make_client(editor_auth)
     reviewer_client = make_client(reviewer_auth)
@@ -42,6 +43,8 @@ async def test_review_signoff(
             [{"op": "add", "path": "/data/members/0", "value": reviewer_id}]
         )
         await setup_client.patch_group(id="product-integrity-reviewers", changes=data)
+        if not keep_existing:
+            await setup_client.delete_records()
 
     # Sample data.
     await editor_client.create_record(

--- a/tests/browser_test.py
+++ b/tests/browser_test.py
@@ -65,9 +65,14 @@ async def test_review_signoff(
     )
     selenium.refresh()
 
-    approve_button: WebElement = selenium.find_element(
-        By.XPATH, "//button[contains(., 'Approve')]"
-    )
+    try:
+        approve_button: WebElement = selenium.find_element(
+            By.XPATH, "//button[contains(., 'Approve')]"
+        )
+    except NoSuchElementException:
+        print(selenium.page_source)  # CI debugging.
+        raise
+
     assert approve_button, "Approve button not found"
     assert approve_button.text == "Approve"
     assert approve_button.is_displayed()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,16 +173,12 @@ def make_client(
 async def flush_default_collection(
     make_client: ClientFactory,
     setup_auth: Auth,
-    source_bucket: str,
-    source_collection: str,
 ):
     yield
     setup_client = make_client(setup_auth)
 
     try:
-        await setup_client.delete_collection(
-            id=source_collection, bucket=source_bucket, if_exists=True
-        )
+        await setup_client.delete_records()
     except KintoException as e:
         # in the case where a user doesn't have permissions to delete
         print(e)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,7 +155,7 @@ def make_client(
             f"{server.split('://')[0]}://", HTTPAdapter(max_retries=retries)
         )
 
-        if not skip_server_setup:
+        if not skip_server_setup and auth:
             create_user(request_session, server, auth)
 
         return AsyncClient(

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -152,6 +152,12 @@ async def test_email_plugin(
             },
         )
 
+    bucket_metadata = await editor_client.get_bucket(id="main-workspace")
+    email_hooks = bucket_metadata["data"]["kinto-emailer"]["hooks"]
+    assert [
+        h for h in email_hooks if "ReviewRequested" in h["event"]
+    ], "Email hook not found"
+
     # Create record, will set status to "work-in-progress"
     await editor_client.create_record(data={"hola": "mundo"})
     # Request review!

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -28,6 +28,9 @@ def canonical_json(records, last_modified):
     return dump
 
 
+pytestmark = pytest.mark.asyncio
+
+
 def test_heartbeat(server: str):
     resp = requests.get(f"{server}/__heartbeat__")
     resp.raise_for_status()


### PR DESCRIPTION
The integration and browser tests don't run on `main`  since 5f2437ed036d202c8311 . Pytest does not have explicit config and skips asyncio tests. 

This PR restores the Pytest config (by mounting pyproject.toml into the root tests container), and fixes a number of integration tests failures introduced in the recent refactoring PRs.

Note: review by commit recommended :) 