### PR TITLE
Upgrade kinto to 14.6.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,16 @@ the version control of each dependency.
 - Add missing ``Last-Modified`` response header in ``/changeset`` responses
 - Don't check groups when review is disabled (#157)
 
+kinto
+-----
+
+**kinto 14.6.0 → 14.6.1**: https://github.com/Kinto/kinto/releases/tag/14.6.1
+
+**Bug Fixes**
+
+- Fix crash in ``/permissions`` endpoint when a setting is misinterpreted as resource permission (e.g. ``signer.auto_create_resources_principals``) (Kinto/kinto#2949)
+
+
 
 27.0.1 (2022-01-13)
 ===================

--- a/requirements.txt
+++ b/requirements.txt
@@ -184,8 +184,8 @@ jsonschema==4.2.1 \
     --hash=sha256:2a0f162822a64d95287990481b45d82f096e99721c86534f48201b64ebca6e8c \
     --hash=sha256:390713469ae64b8a58698bb3cbc3859abe6925b565a973f87323ef21b09a27a8
     # via kinto
-kinto[memcached,monitoring,postgresql]==14.6.0 \
-    --hash=sha256:87fedca110444066b2d9b19e0b498e5812fdb87b9dba51ddac4d92dba5705f80
+kinto[memcached,monitoring,postgresql]==14.6.1 \
+    --hash=sha256:5e707951a1c6a40d41802202293408e7b4ede264484dbe77a1b058675d60ef47
     # via
     #   -r requirements.in
     #   kinto-attachment


### PR DESCRIPTION
Note: the integration tests won't run on this PR (see #166).

However, once merged, we can rebase #166 on main and make sure the re-enabled tests pass there.