### PR TITLE
Use -m instead of --mode for mkdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test: $(INSTALL_STAMP)
 	PYTHONPATH=. $(VENV)/bin/pytest kinto-remote-settings
 
 integration-test:
-	mkdir -p --mode=777 autograph-certs mail
+	mkdir -p -m 777 autograph-certs mail
 	docker-compose run web migrate
 	docker-compose run tests
 

--- a/docs/tutorial-local-server.rst
+++ b/docs/tutorial-local-server.rst
@@ -42,7 +42,7 @@ Create a local folder to receive the potential records attachments, Docker shoul
 
 .. code-block:: bash
 
-    mkdir --mode=777 attachments  # world writable
+    mkdir -m 777 attachments  # world writable
 
 Now, we will run the container with the local configuration file and attachments folder mounted:
 
@@ -69,7 +69,7 @@ We will run the Autograph container in a separate terminal. Since Autograph gene
 
 .. code-block:: bash
 
-    mkdir --mode=777 /tmp/attachments  # world writable
+    mkdir -m 777 /tmp/attachments  # world writable
 
 .. code-block:: bash
 


### PR DESCRIPTION
Apparently MacOS doesn't like the long-form `--mode` argument.

```
$ make integration-test                                                                                                                    
mkdir -p --mode=777 autograph-certs mail
mkdir: illegal option -- -
usage: mkdir [-pv] [-m mode] directory ...
```