### PR TITLE
Fix public port in uwsgi

### DIFF
--- a/config/local.ini
+++ b/config/local.ini
@@ -118,7 +118,6 @@ port = 8888
 
 [uwsgi]
 wsgi-file = app.wsgi
-socket = /tmp/kinto.sock
 master = true
 module = kinto
 static-map = /attachments=/tmp/attachments

--- a/config/testing.ini
+++ b/config/testing.ini
@@ -86,7 +86,6 @@ port = 8888
 
 [uwsgi]
 wsgi-file = app.wsgi
-socket = /tmp/kinto.sock
 master = true
 module = kinto
 static-map = /attachments=/tmp/attachments

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 from typing import Callable, Tuple
 
 import pytest
+import pytest_asyncio
 import requests
 from kinto_http import AsyncClient, KintoException
 from pytest import FixtureRequest
@@ -169,7 +170,7 @@ def make_client(
     return _make_client
 
 
-@pytest.fixture(autouse=True)
+@pytest_asyncio.fixture(autouse=True)
 async def flush_default_collection(
     make_client: ClientFactory,
     setup_auth: Auth,

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -421,6 +421,7 @@ async def test_signer_plugin_rollback(
         await setup_server(setup_client)
 
     editor_client = make_client(editor_auth)
+    await editor_client.patch_collection(data={"status": "to-rollback"})
     before_records = await editor_client.get_records()
 
     await upload_records(editor_client, 5)


### PR DESCRIPTION
With the previous config, `uwsgi` would not listen to the configured port.

I didn't want to change the line in `run.sh` where the port is passed as CLI parameter. 

This fixes it. And should also fix https://github.com/mozilla-services/remote-settings-permissions/pull/302

To verify:

```
$ docker build . -t remotesettings:server
$ docker run --rm -p 8888:8888 remotesettings:server uwsgistart -e KINTO_INI=config/testing.ini
```
Before curl would fail reaching out localhost:8888 