### PR TITLE
Run uwsgi with port by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ CHANGELOG
 This document describes changes between each past release as well as
 the version control of each dependency.
 
+28.0.1 (unreleased)
+===================
+
+**Bug Fixes**
+
+- Fix port mapping with ``uwsgi`` when running container without parameter
+
 
 28.0.0 (2022-02-04)
 ===================

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,4 @@ EXPOSE $PORT
 
 # Run uwsgi by default
 ENTRYPOINT ["/bin/bash", "/app/bin/run.sh"]
-CMD uwsgi --ini ${KINTO_INI}
+CMD uwsgi --http :${PORT} --ini ${KINTO_INI}


### PR DESCRIPTION
With this fix, the container runs uwsgi on the configured port when ran without parameter