### PR TITLE
Fix signing workflow of blocklists in example configs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ the version control of each dependency.
 **Bug Fixes**
 
 - Fix port mapping with ``uwsgi`` when running container without parameter
+- Fix signing workflow of blocklists in example configs (preview bucket should be ``blocklists-preview``)
 
 
 28.0.0 (2022-02-04)

--- a/config/local.ini
+++ b/config/local.ini
@@ -90,7 +90,7 @@ kinto.changes.resources =
 kinto.signer.resources =
     /buckets/main-workspace           -> /buckets/main-preview           -> /buckets/main
     /buckets/security-state-workspace -> /buckets/security-state-preview -> /buckets/security-state
-    /buckets/staging                  -> /buckets/preview                -> /buckets/blocklists
+    /buckets/staging                  -> /buckets/blocklists-preview     -> /buckets/blocklists
 
 kinto.signer.to_review_enabled = true
 kinto.signer.auto_create_resources = true

--- a/config/testing.ini
+++ b/config/testing.ini
@@ -60,7 +60,7 @@ kinto.changes.resources = /buckets/main
 kinto.signer.resources =
     /buckets/main-workspace           -> /buckets/main-preview           -> /buckets/main
     /buckets/security-state-workspace -> /buckets/security-state-preview -> /buckets/security-state
-    /buckets/staging                  -> /buckets/preview                -> /buckets/blocklists
+    /buckets/staging                  -> /buckets/blocklists-preview     -> /buckets/blocklists
 
 kinto.signer.to_review_enabled = false
 


### PR DESCRIPTION
See https://github.com/mozilla-services/cloudops-deployment/blob/dbb19a8373fe061ba65fe9610845a901a3535943/projects/kinto/puppet/modules/kinto/templates/kinto.ini.erb#L166 