### PR TITLE
Monitor all preview buckets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ the version control of each dependency.
 **Bug Fixes**
 
 - Fix port mapping with ``uwsgi`` when running container without parameter
+- Monitor all buckets in default config
 
 
 28.0.0 (2022-02-04)

--- a/config/local.ini
+++ b/config/local.ini
@@ -84,8 +84,12 @@ mail.debug_mailer = true
 #
 
 kinto.changes.resources =
-    /buckets/main-preview
     /buckets/main
+    /buckets/main-preview
+    /buckets/security-state
+    /buckets/security-state-preview
+    /buckets/blocklists
+    /buckets/blocklists-preview
 
 kinto.signer.resources =
     /buckets/main-workspace           -> /buckets/main-preview           -> /buckets/main

--- a/config/testing.ini
+++ b/config/testing.ini
@@ -55,7 +55,13 @@ kinto.attachment.folder = {bucket_id}/{collection_id}
 # Kinto Remote Settings
 #
 
-kinto.changes.resources = /buckets/main
+kinto.changes.resources =
+    /buckets/main
+    /buckets/main-preview
+    /buckets/security-state
+    /buckets/security-state-preview
+    /buckets/blocklists
+    /buckets/blocklists-preview
 
 kinto.signer.resources =
     /buckets/main-workspace           -> /buckets/main-preview           -> /buckets/main


### PR DESCRIPTION
One idea behind those example config files is to be able to run a local environment that behaves like DEV / STAGE

In DEV and STAGE, when you request a review, the preview collection timestamp is updated in the monitor/changes endpoint. 
This was not the case here.

Also, in our Rust client, when the current timestamp is not provided we fetch it from the monitor/changes endpoint. If the preview bucket is not monitored then we cannot fetch/sync the preview records after requesting a review.