### PR TITLE
Circle config updates - docs depdency cache and build_and_publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,7 @@ workflows:
           <<: *pr-filters
           requires:
             - lint_format
-      - build_and_publish:
-          <<: *pr-filters
-          requires:
-            - docs_test
-            - unit_test
-            - integration_test
+
 
   main-workflow:
     jobs:


### PR DESCRIPTION
- Add separate cache for docs deps
- Remove build_and_publish job from pr workflow
  - since we only want to run this job for merges to main and tagged commits