### PR TITLE
Fix running tests container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ maintainer-clean: distclean
 	find . -name '*.orig' -delete
 	docker-compose stop
 	docker-compose rm -f
-	docker volume rm -f $(docker volume ls -q -f name="rs-db-data")
+	RS_DB_DATA_VOL=$$(docker volume ls -q -f name="rs-db-data") ;\
+	[ -z "$$RS_DB_DATA_VOL" ] && docker volume rm -f $$RS_DB_DATA_VOL ;\
 	rm -rf $(VOLUMES_FOLDERS)
 
 $(VENV)/bin/python:

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ maintainer-clean: distclean
 	find . -name '*.orig' -delete
 	docker-compose stop
 	docker-compose rm -f
+	docker volume rm -f $(docker volume ls -q -f name="rs-db-data")
 	rm -rf $(VOLUMES_FOLDERS)
 
 $(VENV)/bin/python:

--- a/README.rst
+++ b/README.rst
@@ -97,12 +97,12 @@ Integration tests can be executed on a remote server.
 .. code-block:: shell
 
     docker-compose run \
-    --env SERVER=https://settings.dev.mozaws.net/v1 \
-    --env MAIL_DIR="" \
-    --env SKIP_SERVER_SETUP=true \
-    --env EDITOR_AUTH=editor:azerty123 \
-    --env REVIEWER_AUTH=reviwer:s3cr3t \
-    tests integration-test
+        --env SERVER=https://settings.dev.mozaws.net/v1 \
+        --env MAIL_DIR="" `# disable tests about emails.` \
+        --env SKIP_SERVER_SETUP=true \
+        --env EDITOR_AUTH=editor:azerty123 \
+        --env REVIEWER_AUTH=reviwer:s3cr3t \
+        tests integration-test
 
 
 Debugging Locally (simple)

--- a/README.rst
+++ b/README.rst
@@ -96,12 +96,13 @@ Integration tests can be executed on a remote server.
 
 .. code-block:: shell
 
-    docker-compose run remotesettings:tests \
-        -e SERVER=http://settings.dev.mozaws.net \
-        -e MAIL_DIR="" \  # disable tests about emails.
-        -e SKIP_SERVER_SETUP=true \
-        -e EDITOR_AUTH=editor:azerty123" \
-        -e REVIEWER_AUTH=reviwer:s3cr3t"
+    docker-compose run \
+    --env SERVER=https://settings.dev.mozaws.net/v1 \
+    --env MAIL_DIR="" \
+    --env SKIP_SERVER_SETUP=true \
+    --env EDITOR_AUTH=editor:azerty123 \
+    --env REVIEWER_AUTH=reviwer:s3cr3t \
+    tests integration-test
 
 
 Debugging Locally (simple)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 version: "3"
 
 volumes:
-  db-data:
+  rs-db-data:
 services:
   db:
     image: postgres:12
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - rs-db-data:/var/lib/postgresql/data
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,4 +78,4 @@ services:
       - $PWD/tests:/app
       - $PWD/mail:/var/debug-mail/
       - $PWD/pyproject.toml:/app/pyproject.toml
-    command: tests
+


### PR DESCRIPTION
I tried running the test container against the dev server according to the docs, but there were a few things are were off, so I did some tweaking according to the [`docker-compose run` docs](https://docs.docker.com/compose/reference/run/).

Additionally, I ran into an issue where data that was persisted in my Postgres container interfered with assumptions made by integration tests. This deserves to be looked at further from the actual tests, but for now I also added a line to `maintainer-clean` that will clear that volume. 