### PR TITLE
Push integration test container to Dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,8 +168,8 @@ jobs:
       - run:
           name: Save containers
           command: |
-            docker save -o /tmp/workspace/rs_server_container.tar.gz remotesettings:server
-            docker save -o /tmp/workspace/rs_test_container.tar.gz remotesettings:tests
+            docker save -o /tmp/workspace/rs_server_container.tar.gz remotesettings/server
+            docker save -o /tmp/workspace/rs_test_container.tar.gz remotesettings/tests
       - persist_to_workspace:
           root: /tmp/workspace
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ jobs:
           name: Load container
           command: |
             docker load -i /tmp/workspace/rs_server_container.tar.gz
+            docker load -i /tmp/workspace/rs_test_container.tar.gz
       - run:
           name: Push to Dockerhub
           command: |

--- a/bin/deploy-dockerhub.sh
+++ b/bin/deploy-dockerhub.sh
@@ -21,6 +21,20 @@ function retry() {
     return 0
 }
 
+# Usage: push_container_to_repo CONTAINER REPO TAG
+# Push container to specified repo with tag
+# Example: push_container_to_repo remotesettings mozilla/remote-settings latest
+function push_container_to_repo() {
+    container=$1
+    repo=$2
+    tag=$3
+    docker tag $container "$repo:$tag" ||
+        (echo "Couldn't tag $container as $repo:$tag" && false)
+    retry 3 docker push "$repo:$tag" ||
+        (echo "Couldn't push $repo:$tag" && false)
+    return 0
+}
+
 # configure docker creds
 echo "$DOCKER_PASS" | docker login -u="$DOCKER_USER" --password-stdin
 
@@ -37,16 +51,8 @@ if [ -n "$1" ]; then
     echo "Tag and push server and integration test containers to Dockerhub"
     echo "${SERVER_DOCKER_REPO}:${TAG}"
     echo "${INTEGRATION_TEST_DOCKER_REPO}:${TAG}"
-
-    docker tag $SERVER_CONTAINER "$SERVER_DOCKER_REPO:$TAG" ||
-        (echo "Couldn't tag $SERVER_CONTAINER as $SERVER_DOCKER_REPO:$TAG" && false)
-    retry 3 docker push "$SERVER_DOCKER_REPO:$TAG" ||
-        (echo "Couldn't push $SERVER_DOCKER_REPO:$TAG" && false)
-
-    docker tag $TEST_CONTAINER "$INTEGRATION_TEST_DOCKER_REPO:$TAG" ||
-        (echo "Couldn't tag $TEST_CONTAINER as $INTEGRATION_TEST_DOCKER_REPO:$TAG" && false)
-    retry 3 docker push "$INTEGRATION_TEST_DOCKER_REPO:$TAG" ||
-        (echo "Couldn't push $INTEGRATION_TEST_DOCKER_REPO:$TAG" && false)
+    push_container_to_repo $SERVER_CONTAINER $SERVER_DOCKER_REPO $TAG
+    push_container_to_repo $TEST_CONTAINER $INTEGRATION_TEST_DOCKER_REPO $TAG
 
     echo "Done."
 fi

--- a/bin/deploy-dockerhub.sh
+++ b/bin/deploy-dockerhub.sh
@@ -26,13 +26,27 @@ echo "$DOCKER_PASS" | docker login -u="$DOCKER_USER" --password-stdin
 
 docker images
 
+SERVER_CONTAINER="remotesettings/server"
+TEST_CONTAINER="remotesettings/tests"
+SERVER_DOCKER_REPO="mozilla/remote-settings"
+INTEGRATION_TEST_DOCKER_REPO="mozilla/remote-settings-integration-tests"
+
 # docker tag and push git branch to dockerhub
 if [ -n "$1" ]; then
     TAG="$1"
-    echo "Tag and push ${DOCKERHUB_REPO}:${TAG} to Dockerhub"
-    docker tag remotesettings:server "$DOCKERHUB_REPO:$TAG" ||
-        (echo "Couldn't tag remote-settings as $DOCKERHUB_REPO:$TAG" && false)
-    retry 3 docker push "$DOCKERHUB_REPO:$TAG" ||
-        (echo "Couldn't push $DOCKERHUB_REPO:$TAG" && false)
+    echo "Tag and push server and integration test containers to Dockerhub"
+    echo "${SERVER_DOCKER_REPO}:${TAG}"
+    echo "${INTEGRATION_TEST_DOCKER_REPO}:${TAG}"
+
+    docker tag $SERVER_CONTAINER "$SERVER_DOCKER_REPO:$TAG" ||
+        (echo "Couldn't tag $SERVER_CONTAINER as $SERVER_DOCKER_REPO:$TAG" && false)
+    retry 3 docker push "$SERVER_DOCKER_REPO:$TAG" ||
+        (echo "Couldn't push $SERVER_DOCKER_REPO:$TAG" && false)
+
+    docker tag $TEST_CONTAINER "$INTEGRATION_TEST_DOCKER_REPO:$TAG" ||
+        (echo "Couldn't tag $TEST_CONTAINER as $INTEGRATION_TEST_DOCKER_REPO:$TAG" && false)
+    retry 3 docker push "$INTEGRATION_TEST_DOCKER_REPO:$TAG" ||
+        (echo "Couldn't push $INTEGRATION_TEST_DOCKER_REPO:$TAG" && false)
+
     echo "Done."
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
   web:
     build:
       context: .
-    image: remotesettings:server
+    image: remotesettings/server
     depends_on:
       - db
       - memcached
@@ -64,7 +64,7 @@ services:
   tests:
     build:
       context: tests
-    image: remotesettings:tests
+    image: remotesettings/tests
     depends_on:
       - web
       - selenium


### PR DESCRIPTION
In addition to pushing the Remote Settings server container to https://hub.docker.com/u/mozilla/remote-settings, we now push the integration test container to https://hub.docker.com/r/mozilla/remote-settings-integration-tests.