### PR TITLE
Install Rust in docker and cache python dependencies by version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,11 @@ version: 2.1
 aliases:
   - &restore_deps_cache
     name: Restoring Python dependency cache
-    key: v3-requirements-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+    key: v3-requirements-{{ checksum ".python.installed" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
 
   - &save_deps_cache
     name: Saving Python dependency cache
-    key: v3-requirements-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+    key: v3-requirements-{{ checksum ".python.installed" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
     paths:
       - .venv
 
@@ -239,6 +239,9 @@ jobs:
           POSTGRES_PASSWORD: postgres
     steps:
       - checkout
+      - run:
+          name: Python version
+          command: python3 --version > .python.installed
       - restore_cache: *restore_deps_cache
       - run:
           name: Run kinto_remote_settings plugin unit tests
@@ -250,6 +253,9 @@ jobs:
       - image: cimg/python:3.10
     steps:
       - checkout
+      - run:
+          name: Python version
+          command: python3 --version > .python.installed
       - restore_cache: *restore_deps_cache
       - run:
           name: Check linting and formatting

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,13 @@
 
 FROM python:3.10.5-bullseye@sha256:dac61c6d3e7ac6deb2926dd96d38090dcba0cb1cf9196ccc5740f25ebe449f50 as compile
 
+# Get rustup https://rustup.rs/ for canonicaljson-rs, because no wheels are published for arm.
+# See https://github.com/mozilla-services/python-canonicaljson-rs/issues/3
+# Use Rust minimal profile https://rust-lang.github.io/rustup/concepts/profiles.html
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
+# Add cargo to PATH
+ENV PATH="/root/.cargo/bin:$PATH"
+
 ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
@@ -18,7 +25,7 @@ RUN uwsgi --build-plugin https://github.com/Datadog/uwsgi-dogstatsd
 FROM python:3.10.5-slim-bullseye@sha256:ca78039cbd3772addb9179953bbf8fe71b50d4824b192e901d312720f5902b22 as server
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    # Needed for UWSGI 
+    # Needed for UWSGI
     libxml2-dev \
     # Needed for psycopg2
     libpq-dev

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update && \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
 ENV PATH="/root/.cargo/bin:$PATH"
 
-RUN pip install --upgrade pip setuptools wheel
+RUN python -m pip install --upgrade pip
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN python -m pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -10,7 +10,11 @@ ENV PYTHONUNBUFFERED=1 \
 USER root
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget
+    apt-get install -y --no-install-recommends wget curl build-essential
+
+# Remove Rust installation when https://github.com/mozilla-services/python-canonicaljson-rs/issues/3 is fixed.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
+ENV PATH="/root/.cargo/bin:$PATH"
 
 RUN pip install --upgrade pip setuptools wheel
 COPY requirements.txt .


### PR DESCRIPTION
This PR caches the python dependencies by Python version.

Without this, if the version of Python is upgraded, the cached compiled dependencies can contain symbols and headers of the previous one. Leading to weird compilation errors (namely with uwsgi).

> Note, this is a follow-up of #236 

This PR also adds Rust to the container in order to compile `python-canonicaljson-rs`, in case the wheels published on Pypi are not available for the host platform (eg. arm).
See https://github.com/mozilla-services/python-canonicaljson-rs/issues/3 and https://github.com/mozilla-services/python-canonicaljson-rs/pull/8
