### PR TITLE
Switch to official Python image in CircleCI jobs that use Docker executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
 
   unit_test:
     docker:
-      - image: cimg/python:3.10
+      - image: python:3.10.5-bullseye@sha256:dac61c6d3e7ac6deb2926dd96d38090dcba0cb1cf9196ccc5740f25ebe449f50
       - image: cimg/postgres:12.8
         environment:
           POSTGRES_DB: testdb
@@ -250,7 +250,7 @@ jobs:
 
   lint_format:
     docker:
-      - image: cimg/python:3.10
+      - image: python:3.10.5-bullseye@sha256:dac61c6d3e7ac6deb2926dd96d38090dcba0cb1cf9196ccc5740f25ebe449f50
     steps:
       - checkout
       - run:
@@ -264,7 +264,7 @@ jobs:
 
   docs_test:
     docker:
-      - image: cimg/python:3.10
+      - image: python:3.10.5-bullseye@sha256:dac61c6d3e7ac6deb2926dd96d38090dcba0cb1cf9196ccc5740f25ebe449f50
     steps:
       - checkout
       - restore_cache:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ maintainer-clean: distclean
 	rm -rf $(VOLUMES_FOLDERS)
 
 $(VENV)/bin/python:
-	virtualenv $(VENV) --python=python3
+	python3 -m venv $(VENV)
 
 $(INSTALL_STAMP): $(VENV)/bin/python requirements.txt requirements-dev.txt
 	$(VENV)/bin/python -m pip install --upgrade pip wheel setuptools


### PR DESCRIPTION
In the CircleCI jobs that run with a [Docker executor](https://circleci.com/docs/2.0/executor-intro#docker), switch from the CircleCI Python image to the official Python image -- the same image we use to build the Remote Settings container.