### PR TITLE
Add `Cache-Control` headers on all `/changeset` endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ CHANGELOG
 This document describes changes between each past release as well as
 the version control of each dependency.
 
+29.1.2 (unreleased)
+===================
+
+**Bug Fixes**
+
+- Add a default ``Cache-Control`` header value on all ``/changeset`` endpoints using the
+  ``kinto.record_cache_expires_seconds`` setting value.
+
+
 29.1.1 (2022-09-21)
 ===================
 

--- a/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
@@ -137,6 +137,9 @@ def _handle_cache_expires(request, bid, cid):
     if cache_expires is not None:
         request.response.cache_expires(seconds=int(cache_expires))
 
+    elif bucket_expires := settings.get(f"{bid}.record_cache_expires_seconds"):
+        request.response.cache_expires(seconds=int(bucket_expires))
+
     elif global_expires := settings.get("record_cache_expires_seconds"):
         request.response.cache_expires(seconds=int(global_expires))
 

--- a/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
@@ -137,6 +137,9 @@ def _handle_cache_expires(request, bid, cid):
     if cache_expires is not None:
         request.response.cache_expires(seconds=int(cache_expires))
 
+    elif global_expires := settings.get("record_cache_expires_seconds"):
+        request.response.cache_expires(seconds=int(global_expires))
+
 
 def _handle_old_since_redirect(request):
     """

--- a/kinto-remote-settings/tests/changes/test_changeset.py
+++ b/kinto-remote-settings/tests/changes/test_changeset.py
@@ -25,6 +25,7 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings["record_cache_expires_seconds"] = "180"
+        settings["main.record_cache_expires_seconds"] = "360"
         settings["blocklists.certificates.record_cache_expires_seconds"] = 1234
         return settings
 
@@ -130,7 +131,17 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
         resp = self.app.get(self.changeset_uri, headers=self.headers)
         assert resp.headers["Cache-Control"] == "max-age=1234"
 
-    def test_cache_control_has_default(self):
+    def test_cache_control_can_be_set_per_bucket(self):
+        self.create_collection("main", "cfr")
+
+        resp = self.app.get(
+            "/buckets/main/collections/cfr/changeset?_expected=0",
+            headers=self.headers,
+        )
+
+        assert resp.headers["Cache-Control"] == "max-age=360"
+
+    def test_cache_control_has_default_if_not_set_explicit_per_collection(self):
         self.create_collection("blocklists", "addons")
 
         resp = self.app.get(

--- a/kinto-remote-settings/tests/changes/test_changeset.py
+++ b/kinto-remote-settings/tests/changes/test_changeset.py
@@ -24,6 +24,7 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
+        settings["record_cache_expires_seconds"] = "180"
         settings["blocklists.certificates.record_cache_expires_seconds"] = 1234
         return settings
 
@@ -128,6 +129,16 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
     def test_cache_control_headers_are_set(self):
         resp = self.app.get(self.changeset_uri, headers=self.headers)
         assert resp.headers["Cache-Control"] == "max-age=1234"
+
+    def test_cache_control_has_default(self):
+        self.create_collection("blocklists", "addons")
+
+        resp = self.app.get(
+            "/buckets/blocklists/collections/addons/changeset?_expected=0",
+            headers=self.headers,
+        )
+
+        assert resp.headers["Cache-Control"] == "max-age=180"
 
     def test_raises_original_backend_errors(self):
         backend = self.app.app.registry.storage


### PR DESCRIPTION
With this pull-request, all `/changeset` endpoints will have their `Cache-Control` response header value set based on the settings, in this order of precedence:

* `kinto.{bid}.{cid}.record_cache_maximum_expires_seconds` if `?_expected` is in querystring, `kinto.{bid}.{cid}.record_cache_expires_seconds` otherwise
* `kinto.{bid}.record_cache_expires_seconds` 
* `kinto.record_cache_expires_seconds` 

This mimics the current behavior of `/records`, as implemented here:
https://github.com/Kinto/kinto/blob/f996279cdcdf9e2eedf268b71a1fbb7ebdac67ce/kinto/views/records.py#L106-L133

> Note for Sven:  The `max-age=86400` is set on redirects, when `?_since=` contains a very old value (default value of `kinto.changes.since_max_age_redirect_ttl_seconds` setting).

* [ ] *TODO* Figure out where/how the `no-store` is coming from