### PR TITLE
Use collection timestamp in `Last-Modified` response header on `/changeset` endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ CHANGELOG
 This document describes changes between each past release as well as
 the version control of each dependency.
 
+30.1.1 (unreleased)
+===================
+
+**Bug Fixes**
+
+- Make sure the ``Last-Modified`` response header of the ``/changeset`` endpoint is bumped when the collection metadata has changed. Otherwise, the CDN won't invalidate the cached responses from the origins when the collections signatures are refreshed.
+
+
 30.1.0 (2022-10-25)
 ===================
 

--- a/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
@@ -308,7 +308,9 @@ def get_changeset(request):
         model = ChangesModel(request)
         metadata = {}
         records_timestamp = model.timestamp()
-        last_modified = records_timestamp  # The collection 'monitor/changes' is virtual.
+        last_modified = (
+            records_timestamp  # The collection 'monitor/changes' is virtual.
+        )
         changes = model.get_objects(
             filters=filters, limit=limit, include_deleted=include_deleted
         )

--- a/kinto-remote-settings/tests/changes/test_changeset.py
+++ b/kinto-remote-settings/tests/changes/test_changeset.py
@@ -46,7 +46,7 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
 
     def test_last_modified_header_is_set(self):
         resp = self.app.get(self.changeset_uri, headers=self.headers)
-        timestamp = resp.json["timestamp"]
+        timestamp = resp.json["metadata"]["last_modified"]
 
         dt = parsedate_to_datetime(resp.headers["Last-Modified"])
 


### PR DESCRIPTION
This change will allow us to align the behavior of the GCP CDN with what we had with Cloudfront.
Indeed, CloudFront was not using this Last-Modified header, and was invalidating origin responses automatically when the TTL had elapsed.

By making sure the `Last-Modified` changes when signatures are refreshed, we make sure the GCP will invalidate the cache too when the TTL has elapsed.

Note: this is not a fix for #186. The problem described in that issue will still exist during the TTL window (configured as 1H)