### PR TITLE
Fix value of changesets' `timestamp` field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,13 +4,21 @@ CHANGELOG
 This document describes changes between each past release as well as
 the version control of each dependency.
 
+31.0.1 (2023-01-10)
+===================
+
+**Bug Fixes**
+
+Fix a regression introduced in #328, where changesets' ``timestamp`` field would reflect the timestamp of collection metadata instead of the records timestamp. Leading to signature verification errors in clients.
+
+
 31.0.0 (2023-01-10)
 ===================
 
 **API changes**
 
 - The timestamps of the monitor/changes entries now reflect the timestamp of the collection metadata (eg. last signature) instead of the records timestamp (eg. last publication).
-  This change will **impact both servers and clients significantly**. See the [related ADR](https://github.com/mozilla/remote-settings/blob/main/docs/adr/adr_002_cache_bust.md) for more details.
+  This change will **impact both servers and clients significantly**. See the `related ADR`<https://github.com/mozilla/remote-settings/blob/main/docs/adr/adr_002_cache_bust.md>`_ for more details.
 
 
 30.1.1 (2022-11-22)

--- a/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
@@ -311,7 +311,9 @@ def get_changeset(request):
 
         model = ChangesModel(request)
         metadata = {}
-        last_modified = model.timestamp()
+        records_timestamp = model.timestamp()
+        # The collection 'monitor/changes' does not have metadata.
+        metadata_timestamp = records_timestamp
         changes = model.get_objects(
             filters=filters, limit=limit, include_deleted=include_deleted
         )
@@ -355,7 +357,7 @@ def get_changeset(request):
             include_deleted=include_deleted,
         )
         # Fetch records timestamp to check integrity.
-        after_timestamp = storage.resource_timestamp(
+        records_timestamp = storage.resource_timestamp(
             resource_name="record", parent_id=collection_uri
         )
 
@@ -365,21 +367,21 @@ def get_changeset(request):
         # Side note: We are sure that the collection timestamp is always higher
         # than the records timestamp, because we have fields like `last_edit_date`
         # in the collection metadata that are automatically bumped when records change.
-        last_modified = metadata["last_modified"]
+        metadata_timestamp = metadata["last_modified"]
 
         # Do not serve inconsistent data.
-        if before_timestamp != after_timestamp:  # pragma: no cover
+        if before_timestamp != records_timestamp:  # pragma: no cover
             raise storage_exceptions.IntegrityError(message="Inconsistent data. Retry.")
 
     # Cache control.
     _handle_cache_expires(request, bid, cid)
 
     # Set Last-Modified response header (Pyramid takes care of converting).
-    request.response.last_modified = last_modified / 1000.0
+    request.response.last_modified = metadata_timestamp / 1000.0
 
     data = {
         "metadata": metadata,
-        "timestamp": last_modified,
+        "timestamp": records_timestamp,
         "changes": changes,
     }
     return data

--- a/kinto-remote-settings/tests/changes/test_changeset.py
+++ b/kinto-remote-settings/tests/changes/test_changeset.py
@@ -30,6 +30,8 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
         return settings
 
     def test_changeset_is_accessible(self):
+        resp = self.app.get(self.records_uri, headers=self.headers)
+        records_timestamp = int(resp.headers["ETag"].replace('"', ""))
         resp = self.app.get(
             "/buckets/blocklists/collections/certificates", headers=self.headers
         )
@@ -44,7 +46,10 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
         assert data["metadata"]["id"] == "certificates"
         assert len(data["changes"]) == 1
         assert data["changes"][0]["dev-edition"] is True
-        assert data["timestamp"] == collection_metadata_timestamp
+
+        assert records_timestamp != collection_metadata_timestamp
+        assert data["metadata"]["last_modified"] == collection_metadata_timestamp
+        assert data["timestamp"] == records_timestamp
 
     def test_last_modified_header_is_set(self):
         resp = self.app.get(self.changeset_uri, headers=self.headers)


### PR DESCRIPTION
In #328 we wanted to change the `last_modified` field of the monitor/changes endpoint to make sure it's bumped when signature are refreshed.
But, accidentally this was changed for every collection (see https://github.com/mozilla/remote-settings/pull/328/files#diff-b86eadd7d9d6e3bf89c937518fbfce0b130e57e264e87a058afa47c295517908L380)

Clients signature verification fail because:

- They build a payload with the collection content using the fields of the changeset endpoint ([source](https://github.com/mozilla-services/remote-settings-client/blob/1f1878aee0aa2ee06efd1973bce2c5de1238aa16/src/client/signatures.rs#L111-L114) or [source](https://searchfox.org/mozilla-central/rev/fb9a504ca73529fa550efe488db2a012a4bf5169/services/settings/RemoteSettingsWorker.js#40-64))
- They verify that the signature of this payload matches the one that the server got from autograph

But, in #328:
- the `timestamp` field of the changeset was now reflecting the collection metadata timestamp 
- but the payload that the server sends to Autograph wasn't changed, it was still using the records timestamp (last publication)

Hence the mismatch.

> Note: The compare view with v30.1.1 helps to see that with this PR, the changeset timestamp isn't affected https://github.com/mozilla/remote-settings/compare/30.1.1...660a57458653f21ff8fbdc6964b218599c292a4f

