### PR TITLE
Use Docker-managed data volumes, profiles for managing services, other Docker tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,8 +225,8 @@ jobs:
       - run:
           name: Load containers
           command: |
-            docker load -i /tmp/workspace/rs_server_container.tar.gz
-            docker load -i /tmp/workspace/rs_test_container.tar.gz
+            docker load -i /tmp/workspace/rs_production_container.tar.gz
+            docker load -i /tmp/workspace/rs_test_runner_container.tar.gz
       - run:
           name: Browser Test
           command: make browser-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
           command: |
             docker save -o /tmp/workspace/rs_local_container.tar.gz remotesettings/local
             docker save -o /tmp/workspace/rs_production_container.tar.gz remotesettings/server
-            docker save -o /tmp/workspace/rs_test_runner_container.tar.gz remotesettings/test
+            docker save -o /tmp/workspace/rs_test_runner_container.tar.gz remotesettings/tests
       - persist_to_workspace:
           root: /tmp/workspace
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,8 +126,8 @@ jobs:
       - run:
           name: Load container
           command: |
-            docker load -i /tmp/workspace/rs_server_container.tar.gz
-            docker load -i /tmp/workspace/rs_test_container.tar.gz
+            docker load -i /tmp/workspace/rs_production_container.tar.gz
+            docker load -i /tmp/workspace/rs_test_runner_container.tar.gz
       - run:
           name: Push to Dockerhub
           command: |
@@ -169,13 +169,15 @@ jobs:
       - run:
           name: Save containers
           command: |
-            docker save -o /tmp/workspace/rs_server_container.tar.gz remotesettings/server
-            docker save -o /tmp/workspace/rs_test_container.tar.gz remotesettings/tests
+            docker save -o /tmp/workspace/rs_local_container.tar.gz remotesettings/local
+            docker save -o /tmp/workspace/rs_production_container.tar.gz remotesettings/server
+            docker save -o /tmp/workspace/rs_test_runner_container.tar.gz remotesettings/test
       - persist_to_workspace:
           root: /tmp/workspace
           paths:
-            - rs_server_container.tar.gz
-            - rs_test_container.tar.gz
+            - rs_local_container.tar.gz
+            - rs_production_container.tar.gz
+            - rs_test_runner_container.tar.gz
 
   integration_test:
     machine:
@@ -197,8 +199,8 @@ jobs:
       - run:
           name: Load containers
           command: |
-            docker load -i /tmp/workspace/rs_server_container.tar.gz
-            docker load -i /tmp/workspace/rs_test_container.tar.gz
+            docker load -i /tmp/workspace/rs_local_container.tar.gz
+            docker load -i /tmp/workspace/rs_test_runner_container.tar.gz
       - run:
           name: Integration Test
           command: make integration-test

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,9 @@ the version control of each dependency.
 
 **Internal Changes**
 
-- Docker / docker-compose changes
+- Improve Docker volume management
+- Add Docker compose profile support for test services
+- Move ``kinto-remote-settings`` plugin build step to ``compile`` stage of Dockerfile
 
 31.0.1 (2023-02-14)
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ This document describes changes between each past release as well as
 the version control of each dependency.
 
 
+31.0.2.dev (unreleased)
+===================
+
+**Internal Changes**
+
+- Docker / docker-compose changes
+
 31.0.1 (2023-02-14)
 ===================
 

--- a/IntegrationTests.Dockerfile
+++ b/IntegrationTests.Dockerfile
@@ -14,5 +14,5 @@ RUN pip install --no-cache-dir -r /opt/requirements.txt
 
 WORKDIR /app
 COPY tests/ pyproject.toml ./
-
+# ./tests/run.sh, not ./bin/run.sh
 ENTRYPOINT ["/app/run.sh"]

--- a/IntegrationTests.Dockerfile
+++ b/IntegrationTests.Dockerfile
@@ -15,4 +15,4 @@ RUN pip install --no-cache-dir -r /opt/requirements.txt
 WORKDIR /app
 COPY tests/ pyproject.toml ./
 
-ENTRYPOINT ["/bin/bash", "/app/run.sh"]
+ENTRYPOINT ["/app/run.sh"]

--- a/IntegrationTests.Dockerfile
+++ b/IntegrationTests.Dockerfile
@@ -13,6 +13,6 @@ COPY tests/requirements.txt /opt
 RUN pip install --no-cache-dir -r /opt/requirements.txt
 
 WORKDIR /app
-COPY tests .
+COPY tests/ pyproject.toml ./
 
 ENTRYPOINT ["/bin/bash", "/app/run.sh"]

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ browser-test:
 
 build:
 	docker build --file RemoteSettings.Dockerfile --target production --tag remotesettings/server .
-	docker-compose build
+	docker-compose --profile integration-test build
 
 build-db:
 ifdef PSQL_INSTALLED

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ INSTALL_STAMP := $(VENV)/.install.stamp
 DOC_STAMP := $(VENV)/.doc.install.stamp
 SPHINX_BUILDDIR = docs/_build
 PSQL_INSTALLED := $(shell psql --version 2>/dev/null)
-VOLUMES_FOLDERS := autograph-certs mail
 
 clean:
 	find . -name '*.pyc' -delete
@@ -18,11 +17,7 @@ maintainer-clean: distclean
 	rm -rf .pytest_cache
 	rm -rf tests/.pytest_cache
 	find . -name '*.orig' -delete
-	docker-compose stop
-	docker-compose rm -f
-	RS_DB_DATA_VOL=$$(docker volume ls -q -f name="rs-db-data") ;\
-	[ -z "$$RS_DB_DATA_VOL" ] && docker volume rm -f $$RS_DB_DATA_VOL ;\
-	rm -rf $(VOLUMES_FOLDERS)
+	docker-compose down --remove-orphans --volumes --rmi all
 
 $(VENV)/bin/python:
 	python3 -m venv $(VENV)
@@ -48,16 +43,15 @@ test: $(INSTALL_STAMP)
 	$(VENV)/bin/coverage report -m --fail-under 99
 
 integration-test:
-	mkdir -p -m 777 $(VOLUMES_FOLDERS)
 	docker-compose run --rm web migrate
 	docker-compose run --rm tests integration-test
 
 browser-test:
-	mkdir -p -m 777 $(VOLUMES_FOLDERS)
 	docker-compose run --rm web migrate
 	docker-compose run --rm tests browser-test
 
 build:
+	docker build --file RemoteSettings.Dockerfile --target production --tag remotesettings/server .
 	docker-compose build
 
 build-db:
@@ -73,6 +67,7 @@ endif
 
 start:
 	make build
+	docker-compose run --rm web migrate
 	docker-compose up
 
 stop:

--- a/RemoteSettings.Dockerfile
+++ b/RemoteSettings.Dockerfile
@@ -24,8 +24,6 @@ RUN /opt/update_and_install_system_packages.sh \
     # Needed for psycopg2
     libpq-dev
 
-
-
 COPY --from=compile $VIRTUAL_ENV $VIRTUAL_ENV
 
 WORKDIR /app
@@ -41,6 +39,6 @@ RUN python -m kinto_remote_settings.signer.generate_keypair /app/ecdsa.private.p
 
 EXPOSE $PORT
 USER app
-# Run uwsgi by default
 ENTRYPOINT ["/bin/bash", "/app/bin/run.sh"]
-CMD ["sh", "-c", "uwsgi --http :${PORT} --ini ${KINTO_INI}"]
+# Run uwsgi by default
+CMD ["start"]

--- a/RemoteSettings.Dockerfile
+++ b/RemoteSettings.Dockerfile
@@ -39,6 +39,6 @@ RUN python -m kinto_remote_settings.signer.generate_keypair /app/ecdsa.private.p
 
 EXPOSE $PORT
 USER app
-ENTRYPOINT ["/bin/bash", "/app/bin/run.sh"]
+ENTRYPOINT ["./bin/run.sh"]
 # Run uwsgi by default
 CMD ["start"]

--- a/RemoteSettings.Dockerfile
+++ b/RemoteSettings.Dockerfile
@@ -47,4 +47,4 @@ CMD ["start"]
 
 FROM production as local
 # create directories for volume mounts used in integration tests / local development
-RUN mkdir -m 777 /app/mail && mkdir -m 777 /tmp/attachments
+RUN mkdir -p -m 777 /app/mail && mkdir -p -m 777 /tmp/attachments

--- a/RemoteSettings.Dockerfile
+++ b/RemoteSettings.Dockerfile
@@ -9,7 +9,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt && \
     uwsgi --build-plugin https://github.com/Datadog/uwsgi-dogstatsd
 
-FROM python:3.11.2-slim as server
+FROM python:3.11.2-slim as production
 
 ENV KINTO_INI=config/local.ini \
     PATH="/opt/venv/bin:$PATH" \
@@ -42,3 +42,7 @@ USER app
 ENTRYPOINT ["./bin/run.sh"]
 # Run uwsgi by default
 CMD ["start"]
+
+FROM production as local
+# create directories for volume mounts used in integration tests / local development
+RUN mkdir -m 777 /app/mail && mkdir -m 777 /tmp/attachments

--- a/RemoteSettings.Dockerfile
+++ b/RemoteSettings.Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /opt
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt && \
     uwsgi --build-plugin https://github.com/Datadog/uwsgi-dogstatsd
+COPY ./kinto-remote-settings ./kinto-remote-settings
+COPY VERSION .
+RUN pip install --no-cache-dir ./kinto-remote-settings
 
 FROM python:3.11.2-slim as production
 
@@ -32,7 +35,6 @@ RUN chown 10001:10001 /app && \
     useradd --no-create-home --uid 10001 --gid 10001 --home-dir /app app
 COPY --chown=app:app . .
 COPY --from=compile /opt/dogstatsd_plugin.so .
-RUN pip install --no-cache-dir ./kinto-remote-settings
 
 # Generate local key pair to simplify running without Autograph out of the box (see `config/testing.ini`)
 RUN python -m kinto_remote_settings.signer.generate_keypair /app/ecdsa.private.pem /app/ecdsa.public.pem

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -2,20 +2,16 @@
 set -eo pipefail
 
 usage() {
-  echo "usage: ./bin/run.sh migrate|start|uwsgistart|bash|whatevercommandyouwant"
+  echo "usage: ./bin/run.sh migrate|start|whatevercommandyouwant"
   exit 1
 }
 
 [ $# -lt 1 ] && usage
-
 case $1 in
   migrate)
     kinto migrate --ini $KINTO_INI
     ;;
   start)
-    kinto start --ini $KINTO_INI
-    ;;
-  uwsgistart)
     uwsgi --http :$PORT --ini $KINTO_INI
     ;;
   *)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,15 @@
 version: "3"
 
 volumes:
-  rs-db-data:
+  db-data:
+  debug-mail:
+  autograph-certs:
+  attachments:
 services:
   db:
     image: postgres:12
     volumes:
-      - rs-db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql/data
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       PGUSER: postgres
@@ -21,13 +24,14 @@ services:
 
   autograph:
     image: mozilla/autograph
+    user: root
     volumes:
-      - $PWD/autograph-certs:/tmp/autograph
+      - autograph-certs:/tmp/autograph
 
   certchains:
     image: httpd:2
     volumes:
-      - $PWD/autograph-certs:/usr/local/apache2/htdocs/
+      - autograph-certs:/usr/local/apache2/htdocs/
     depends_on:
       - autograph
     ports:
@@ -45,7 +49,8 @@ services:
   web:
     build:
       dockerfile: RemoteSettings.Dockerfile
-    image: remotesettings/server
+      target: local
+    image: remotesettings/local
     depends_on:
       - db
       - memcached
@@ -60,8 +65,10 @@ services:
     ports:
       - 8888:8888
     volumes:
-      - $PWD:/app
-    command: uwsgistart
+      - ./config:/app/config
+      - ./kinto-remote-settings:/app/kinto-remote-settings
+      - debug-mail:/app/mail
+      - attachments:/tmp/attachments
 
   tests:
     build:
@@ -78,6 +85,6 @@ services:
       - SELENIUM_PORT=4444
       - MAIL_DIR=/var/debug-mail/
     volumes:
-      - $PWD/tests:/app
-      - $PWD/mail:/var/debug-mail/
+      - ./tests:/app
+      - debug-mail:/var/debug-mail/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
 
   selenium:
     image: selenium/standalone-firefox
+    profiles: [integration-test]
     volumes:
       - /dev/shm:/dev/shm
     ports:
@@ -66,6 +67,7 @@ services:
     build:
       dockerfile: IntegrationTests.Dockerfile
     image: remotesettings/tests
+    profiles: [integration-test]
     depends_on:
       - web
       - selenium

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,5 +80,4 @@ services:
     volumes:
       - $PWD/tests:/app
       - $PWD/mail:/var/debug-mail/
-      - $PWD/pyproject.toml:/app/pyproject.toml
 


### PR DESCRIPTION
This PR:
- specifies [profiles](https://docs.docker.com/compose/profiles/) for Docker compose so that, among other things, running `make start` (`docker compose up`) doesn't also spin up Selenium and the tests container

- Modifies our compose / Dockerfile setup so that we can rely on just Docker volumes to manage data for local development and integration tests
There isn't a super clean way to control permissions for named volumes, and this does add a little complexity to our Docker setup overall. But, I think it is nicer to have docker-compose manage volumes and to not have test data end up in the root directory.

- moves building the main `kinto-remote-settings` plugin to the `compile` stage
This means we don't have do repeat this step every time we change something in the project directory, since we'd first `COPY . .` before bulding the plugin

- tweaks the way we specify `ENTRYPOINT` and `CMD` instructions