### PR TITLE
Fix sensitive urls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,12 @@ test: $(INSTALL_STAMP)
 	$(VENV)/bin/coverage report -m --fail-under 99
 
 integration-test:
+	docker-compose build tests
 	docker-compose run --rm web migrate
 	docker-compose run --rm tests integration-test
 
 browser-test:
+	docker-compose build tests
 	docker-compose run --rm web migrate
 	docker-compose run --rm tests browser-test
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,5 @@ services:
       - SELENIUM_PORT=4444
       - MAIL_DIR=/var/debug-mail/
     volumes:
-      - ./tests:/app
       - debug-mail:/var/debug-mail/
 


### PR DESCRIPTION
Though we landed #380, I noticed that the `sensitive_url` was still being set to `.*` ([e.g.](https://app.circleci.com/pipelines/github/mozilla/remote-settings/714/workflows/8b1dd86e-55da-4aaa-9108-41735879db61/jobs/3784?invite=true#step-105-9200)).

I think this is because [even though we were copying the top-level `pyproject.toml` to the tests container](https://github.com/mozilla/remote-settings/blob/388ba8739df8f4bcf122e9c0c60796d390dc4f3c/IntegrationTests.Dockerfile#L16), we were [mounting the `tests` volume to the container in Docker Compose](https://github.com/mozilla/remote-settings/blob/388ba8739df8f4bcf122e9c0c60796d390dc4f3c/docker-compose.yml#L88), which wouldn't include the copied `pyproject.toml`.

So now, we remove that volume mount and rebuild the `tests` container before running the browser or integration tests.

This shouldn't affect development cycle time _too_ much, since there isn't a lot to copy to the tests container before finishing the build.


