### PR TITLE
Fix #400: rely on `/changeset` endpoint for signature integration tests

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@ aiohttp==3.8.4
 autograph-utils==0.1.1
 canonicaljson-rs==0.5.0
 httpie==3.2.1
-kinto-http==11.0.0
+kinto-http==11.0.1
 pytest==6.2.5
 pytest-asyncio==0.20.3
 pytest-selenium==4.0.0


### PR DESCRIPTION
Fix #400