### PR TITLE
Fixes #410: Reorder float error message so path is at the end

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ the version control of each dependency.
 31.0.2.dev (unreleased)
 ===================
 
+**Bug Fixes**
+
+- Fixes #410: Reorder float error message so path is at the end
+
 **Internal Changes**
 
 - Improve Docker volume management

--- a/kinto-remote-settings/src/kinto_remote_settings/signer/listeners.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/signer/listeners.py
@@ -379,7 +379,7 @@ def prevent_float_value(event, resources):
             path = f"{path}.{k}" if path else k
             if isinstance(v, float):
                 raise ValueError(
-                    f"'{path}' field contains float value (tip: use integer or string)"
+                    f"field contains float value (tip: use integer or string), '{path}'"
                 )
             elif isinstance(v, (list, dict)):
                 scan(v, path)


### PR DESCRIPTION
The `path` where a float is detected can be quite long.  Some tools like Sentry can truncate the error message so the useful error message is removed.

This makes troubleshooting more challenging and less obvious.  Moving the path to the end makes it clearer what the error is and where to start looking for the problem.