### PR TITLE
Reduce size of downloaded history in integration tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ This document describes changes between each past release as well as
 the version control of each dependency.
 
 
+31.0.3.dev (unreleased)
+=======================
+
+**Bug Fixes**
+
+- Reduce size of downloaded history in integration tests
+
+
 31.0.2 (2023-04-13)
 ===================
 


### PR DESCRIPTION
Otherwise calling `editor_client.get_history()` will fetch all history entries of the `main-workspace` bucket since epoch 