### PR TITLE
Show number of commits since last tag in version endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
           name: Create version.json
           command: |
             # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/main/docs/version_object.md
-            LATEST_TAG=$(git describe --tags --abbrev=0)
+            LATEST_TAG=$(git describe --tags --abbrev=4 HEAD~)
             printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
             "$CIRCLE_SHA1" \
             "${CIRCLE_TAG:-$LATEST_TAG}" \

--- a/kinto-remote-settings/setup.py
+++ b/kinto-remote-settings/setup.py
@@ -5,7 +5,7 @@ import setuptools
 
 
 path = Path(__file__).parent.parent / "version.json"
-version = json.load(open(path))["version"].replace("v", "")
+version = json.load(open(path))["version"].replace("v", "").split("-")[0]
 
 INSTALL_REQUIRES = [
     "kinto",


### PR DESCRIPTION
Since the DEV instance is redeployed on each commit, it should not show the latest tag in the version endpoint, but a fully qualified version (number of commits since last tag and commit hash) 
Thanks Sven for the suggestion

> note: https://github.com/mozilla-services/telescope/pull/1309 will be need for deployed versions checks to remain green