### PR TITLE
Do not skip current commit when describing current tagged version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
           name: Create version.json
           command: |
             # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/main/docs/version_object.md
-            LATEST_TAG=$(git describe --tags --abbrev=4 HEAD~)
+            LATEST_TAG=$(git describe --tags --abbrev=4 HEAD)
             printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
             "$CIRCLE_SHA1" \
             "${CIRCLE_TAG:-$LATEST_TAG}" \


### PR DESCRIPTION
```
$ git log
016079a8514697c0533f4778697eb1faa92b14ed (HEAD -> main, tag: 31.1.1, origin/main) Show number of commits since last tag in version endpoint (#464)
82f251c590c0576b962fe2874c333acb82138fa2 Bump sphinx from 7.2.5 to 7.2.6 (#462)
87cc8d909cebcf68b1ba935cd227b7df65186995 Upgrade to kinto 16.2.1 to remove superfluous Sentry warnings (#461)
faa96ce2ae4a2af7db80f0d5a7c85a675e1f00f4 Bump kinto from 16.1.0 to 16.2.1 (#463)
9377d90bf0197610705c44d2dcbf3a03e52801d0 Bump black from 23.7.0 to 23.9.1 (#460)
06e904c8f0b5a604e0b2313e358c619803c4e170 Bump coverage from 7.3.0 to 7.3.1 (#457)
409580ea230898018bc857beb3f26f7c99987f41 Bump pytest from 7.4.1 to 7.4.2 (#459)
e0d27f82430c89c2228c9ce60910f389a30d3aea (tag: 31.1.0) Ref #284: Do not let heartbeat fail if Autograph expires soon (#456)
c8e4018cc012b1660334544ec91360b4e9b2cbc3 (fix-querystring-encoding) Bump pytest from 7.4.0 to 7.4.1 (#454)
02c9baac73fbce48fd7947c04674cd94424e5f84 Bump sphinx from 7.2.2 to 7.2.5 (#455)
....
```

```
$ git describe --tags --abbrev=4 HEAD
31.1.1
```

```
git describe --tags --abbrev=4 HEAD~
31.1.0-6-g82f2
```