### PR TITLE
Add caching for web / test container builds in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,8 @@ jobs:
       - run: mkdir ${DOCKER_CACHE}
         
       - name: Compute cache key
-        run: echo "CACHE_KEY=$(git ls-tree --full-tree -r --name-only HEAD | grep -v -f RemoteSettings.dockerignore | git hash-object --stdin)" >> $GITHUB_ENV
+        # Create hash of hashes of checked in files not in Dockerignore
+        run: echo "CACHE_KEY=$(git ls-tree --full-tree -r HEAD | grep -v -f RemoteSettings.dockerignore | awk '{print $3}' | git hash-object --stdin)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         with:
@@ -146,7 +147,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Compute cache key
-        run: echo "CACHE_KEY=$(git ls-tree --full-tree -r --name-only HEAD | grep -v -f RemoteSettings.dockerignore | git hash-object --stdin)" >> $GITHUB_ENV
+        # Create hash of hashes of checked in files not in Dockerignore
+        run: echo "CACHE_KEY=$(git ls-tree --full-tree -r HEAD | grep -v -f RemoteSettings.dockerignore | awk '{print $3}' | git hash-object --stdin)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,16 +95,90 @@ jobs:
         run: make test
   integration_test:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CACHE: /tmp/docker-cache
     steps:
       - uses: actions/checkout@v3
+
+      - run: |
+          mkdir -p ${DOCKER_CACHE}/web
+          mkdir -p ${DOCKER_CACHE}/tests
+
+      - name: Compute cache key
+        run: echo "CACHE_KEY=$(git ls-tree --full-tree -r --name-only HEAD | grep -v -f RemoteSettings.dockerignore | git hash-object --stdin)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.DOCKER_CACHE}}
+          key: docker-build-${{ hashFiles('RemoteSettings.Dockerfile', 'IntegrationTests.Dockerfile') }}-${{ env.CACHE_KEY }}
+          restore-keys: |
+            docker-build-${{ hashFiles('RemoteSettings.Dockerfile', 'IntegrationTests.Dockerfile') }}-${{ env.CACHE_KEY }}
+            docker-build-${{ hashFiles('RemoteSettings.Dockerfile', 'IntegrationTests.Dockerfile') }}-
+            docker-build-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+      
+      - name: Pre-build image caches
+        run: |
+          docker buildx build \
+            --cache-from type=local,src=${DOCKER_CACHE}/web \
+            --cache-to type=local,dest=${DOCKER_CACHE}/web,mode=max \
+            --file RemoteSettings.Dockerfile .
+
+          docker buildx build \
+            --cache-from type=local,src=${DOCKER_CACHE}/tests \
+            --cache-to type=local,dest=${DOCKER_CACHE}/tests,mode=max \
+            --file IntegrationTests.Dockerfile .
+
       - name: Run integration tests
         run: make integration-test
+
   browser-test:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CACHE: /tmp/docker-cache
     steps:
       - uses: actions/checkout@v3
+      
+      - run: |
+          mkdir -p ${DOCKER_CACHE}/web
+          mkdir -p ${DOCKER_CACHE}/tests
+      
+      - name: Compute cache key
+        run: echo "CACHE_KEY=$(git ls-tree --full-tree -r --name-only HEAD | grep -v -f RemoteSettings.dockerignore | git hash-object --stdin)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.DOCKER_CACHE}}
+          key: docker-build-${{ hashFiles('RemoteSettings.Dockerfile', 'IntegrationTests.Dockerfile') }}-${{ env.CACHE_KEY }}
+          restore-keys: |
+            docker-build-${{ hashFiles('RemoteSettings.Dockerfile', 'IntegrationTests.Dockerfile') }}-${{ env.CACHE_KEY }}
+            docker-build-${{ hashFiles('RemoteSettings.Dockerfile', 'IntegrationTests.Dockerfile') }}-
+            docker-build-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+      
+      - name: Pre-build image caches
+        run: |
+          docker buildx build \
+            --cache-from type=local,src=${DOCKER_CACHE}/web \
+            --cache-to type=local,dest=${DOCKER_CACHE}/web,mode=max \
+            --file RemoteSettings.Dockerfile .
+
+          docker buildx build \
+            --cache-from type=local,src=${DOCKER_CACHE}/tests \
+            --cache-to type=local,dest=${DOCKER_CACHE}/tests,mode=max \
+            --file IntegrationTests.Dockerfile .
+
       - name: Run browser tests
         run: make browser-test
+
   review-dependabot-pr:
     permissions:
       contents: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,11 +99,9 @@ jobs:
       DOCKER_CACHE: /tmp/docker-cache
     steps:
       - uses: actions/checkout@v3
-
-      - run: |
-          mkdir -p ${DOCKER_CACHE}/web
-          mkdir -p ${DOCKER_CACHE}/tests
-
+      
+      - run: mkdir ${DOCKER_CACHE}
+        
       - name: Compute cache key
         run: echo "CACHE_KEY=$(git ls-tree --full-tree -r --name-only HEAD | grep -v -f RemoteSettings.dockerignore | git hash-object --stdin)" >> $GITHUB_ENV
 
@@ -121,17 +119,21 @@ jobs:
         with:
           install: true
       
-      - name: Pre-build image caches
-        run: |
-          docker buildx build \
-            --cache-from type=local,src=${DOCKER_CACHE}/web \
-            --cache-to type=local,dest=${DOCKER_CACHE}/web,mode=max \
-            --file RemoteSettings.Dockerfile .
+      - name: Build web container
+        uses: docker/build-push-action@v5
+        with:
+          cache-from: type=local,src=${{ env.DOCKER_CACHE}}/web
+          cache-to: type=local,dest=${{ env.DOCKER_CACHE}}/web,mode=max
+          file: RemoteSettings.Dockerfile
+          context: .
 
-          docker buildx build \
-            --cache-from type=local,src=${DOCKER_CACHE}/tests \
-            --cache-to type=local,dest=${DOCKER_CACHE}/tests,mode=max \
-            --file IntegrationTests.Dockerfile .
+      - name: Build test container
+        uses: docker/build-push-action@v5
+        with:
+          cache-from: type=local,src=${{ env.DOCKER_CACHE}}/tests
+          cache-to: type=local,dest=${{ env.DOCKER_CACHE}}/tests,mode=max
+          file: IntegrationTests.Dockerfile
+          context: .
 
       - name: Run integration tests
         run: make integration-test
@@ -142,11 +144,7 @@ jobs:
       DOCKER_CACHE: /tmp/docker-cache
     steps:
       - uses: actions/checkout@v3
-      
-      - run: |
-          mkdir -p ${DOCKER_CACHE}/web
-          mkdir -p ${DOCKER_CACHE}/tests
-      
+
       - name: Compute cache key
         run: echo "CACHE_KEY=$(git ls-tree --full-tree -r --name-only HEAD | grep -v -f RemoteSettings.dockerignore | git hash-object --stdin)" >> $GITHUB_ENV
 
@@ -164,17 +162,21 @@ jobs:
         with:
           install: true
       
-      - name: Pre-build image caches
-        run: |
-          docker buildx build \
-            --cache-from type=local,src=${DOCKER_CACHE}/web \
-            --cache-to type=local,dest=${DOCKER_CACHE}/web,mode=max \
-            --file RemoteSettings.Dockerfile .
+      - name: Build web container
+        uses: docker/build-push-action@v5
+        with:
+          cache-from: type=local,src=${{ env.DOCKER_CACHE}}/web
+          cache-to: type=local,dest=${{ env.DOCKER_CACHE}}/web,mode=max
+          file: RemoteSettings.Dockerfile
+          context: .
 
-          docker buildx build \
-            --cache-from type=local,src=${DOCKER_CACHE}/tests \
-            --cache-to type=local,dest=${DOCKER_CACHE}/tests,mode=max \
-            --file IntegrationTests.Dockerfile .
+      - name: Build test container
+        uses: docker/build-push-action@v5
+        with:
+          cache-from: type=local,src=${{ env.DOCKER_CACHE}}/tests
+          cache-to: type=local,dest=${{ env.DOCKER_CACHE}}/tests,mode=max
+          file: IntegrationTests.Dockerfile
+          context: .
 
       - name: Run browser tests
         run: make browser-test

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ maintainer-clean: distclean ## Delete all non versioned files
 	rm -rf .pytest_cache
 	rm -rf tests/.pytest_cache
 	find . -name '*.orig' -delete
-	docker-compose down --remove-orphans --volumes --rmi all
+	docker compose down --remove-orphans --volumes --rmi all
 
 $(VENV)/bin/python:  ## Create virtualenv
 	python3 -m venv $(VENV)
@@ -49,18 +49,18 @@ test: $(INSTALL_STAMP)  ## Run unit tests
 	$(VENV)/bin/coverage report -m --fail-under 99
 
 integration-test:  ## Run integration tests using Docker
-	docker-compose build tests
-	docker-compose run --rm web migrate
-	docker-compose run --rm tests integration-test
+	docker compose build tests
+	docker compose run --rm web migrate
+	docker compose run --rm tests integration-test
 
 browser-test:  ## Run browser tests using Docker
-	docker-compose build tests
-	docker-compose run --rm web migrate
-	docker-compose run --rm tests browser-test
+	docker compose build tests
+	docker compose run --rm web migrate
+	docker compose run --rm tests browser-test
 
 build:  ## Build containers
 	docker build --file RemoteSettings.Dockerfile --target production --tag remotesettings/server .
-	docker-compose --profile integration-test build
+	docker compose --profile integration-test build
 
 build-db:  ## Initialize database 'postgresql://postgres@localhost/testdb'
 ifdef PSQL_INSTALLED
@@ -74,15 +74,15 @@ else
 endif
 
 start:  ## Run the services using Docker
-	make build
-	docker-compose run --rm web migrate
-	docker-compose up
+	docker compose build
+	docker compose run --rm web migrate
+	docker compose up
 
 stop:  ## Stop the services
-	docker-compose stop
+	docker compose stop
 
 down:  ## Shutwdown all containers
-	docker-compose down
+	docker compose down
 
 install-docs: $(VENV)/bin/python $(DOC_STAMP)  ## Install documentation build dependencies
 $(DOC_STAMP): poetry.lock


### PR DESCRIPTION
This PR adds caching for container builds for our integration and browser tests in CI.

In a recent PR on our `main` branch, browser and integration tests took roughly 5m 15s to run ([src](https://github.com/mozilla/remote-settings/actions/runs/6642086964))


On the first, uncached run of this workflow (in a fork), [we can see](https://github.com/grahamalama/remote-settings/actions/runs/6644408410) that about 2m 47s are dedicated to building our containers (minus some time to persist layers to the cache).

<img width="622" alt="image" src="https://github.com/mozilla/remote-settings/assets/20747904/11ed3759-298b-4503-90fb-1285dec9ed8f">


But [after the cache is populated](https://github.com/grahamalama/remote-settings/actions/runs/6644513916), that build time drops down to ~47s

<img width="661" alt="image" src="https://github.com/mozilla/remote-settings/assets/20747904/483867b4-003d-4a8c-a2b0-2782078e820e">

While this is a nice improvement, one issue with the current approach is that the size of the cache is quite large at around ~770mb

<img width="981" alt="image" src="https://github.com/mozilla/remote-settings/assets/20747904/52765b9e-c7ac-41fa-8526-ed1a92482b83">


Since Github Actions only provides 10GB of cache storage per repo, we'll start running out of cache room rather quickly. Github will start evicting our oldest caches to make room for new ones, which could cause unexpected slow builds. ([docs](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy))

Maybe there's a better caching strategy than the one that's currently in this PR that balances cache size and usefulness. Happy to hear ideas.

