### PR TITLE
Add docs about monitoring

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Remote Settings is a Mozilla service that makes it easy to manage evergreen sett
    getting-started
    case-studies
    support
+   monitoring
    target-filters
    screencasts
    tutorial-dev-server

--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -1,0 +1,85 @@
+.. _monitoring:
+
+Monitoring
+==========
+
+Delivery Checks
+---------------
+
+The Remote Settings ecosystem can be monitored from the `Delivery Checks dashboard <https://delivery-checks.prod.mozaws.net/>`_.
+
+Each environment has its own set of checks, and generally speaking if the checks pass, the service is operating without issues.
+
+.. note::
+
+    This is an instance of `Telescope <https://github.com/mozilla-services/telescope>`_, a generic health check service that you can use for your services!
+
+Server Metrics
+--------------
+
+Servers send live metrics which are visible in Grafana.
+
+We have a `remote-settings folder <https://earthangel-b40313e5.influxcloud.net/dashboards/f/09aCU2uVk/remote-settings>`_ with the main dashboards.
+
+Server Logs
+-----------
+
+Servers logs are available in the Google Cloud Console `Logs Explorer <https://console.cloud.google.com/logs/>`_.
+
+
+Writer Instances
+''''''''''''''''
+
+::
+
+    TBD
+
+Reader Instances
+''''''''''''''''
+
+::
+
+    TBD
+
+Attachments CDN Logs
+''''''''''''''''''''
+
+::
+
+    httpRequest.requestUrl =~ "attachments"
+
+
+Clients Telemetry
+-----------------
+
+Clients send us uptake statuses, that we can query and graph over time in Redash.
+
+Redash Queries
+''''''''''''''
+
+- `Signature errors by version <https://sql.telemetry.mozilla.org/queries/82717>`_
+- `Sync error investigation (last 36H) <https://sql.telemetry.mozilla.org/queries/67923>`_
+- `Synchronization errors distribution <https://sql.telemetry.mozilla.org/queries/68824>`_
+- `Remote Settings clients stuck in the past <https://sql.telemetry.mozilla.org/queries/81955>`_
+- `Profiles with broken sync (last 120H) <https://sql.telemetry.mozilla.org/queries/85521>`_
+
+.. notes::
+
+    Most queries filter on the last X hours with ``WHERE timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {{X}} HOUR)``
+    but it's possible to query a specific time window with:
+
+    ::
+        WHERE timestamp > timestamp '2023-10-24 06:00:00'
+          AND timestamp < timestamp '2023-10-24 22:00:00'
+
+.. notes::
+
+    These queries may require permissions, don't hesitate to request access on Slack in ``#delivery``.
+
+Telescope Check Queries
+'''''''''''''''''''''''
+
+These queries can be used as models when troubleshooting with Redash:
+
+- `Events per period of 10min <https://github.com/mozilla-services/telescope/blob/641587b5a37c7f1ae8fa911dbd516bcb4bf102c7/checks/remotesettings/uptake_error_rate.py#L27-L63>`_
+- `Percentiles on sync duration and age of pulled data <https://github.com/mozilla-services/telescope/blob/641587b5a37c7f1ae8fa911dbd516bcb4bf102c7/checks/remotesettings/uptake_max_age.py#L16-L62>`_

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -9,6 +9,8 @@ Troubleshooting
 * Open a `Server Side ticket <https://bugzilla.mozilla.org/enter_bug.cgi?product=Cloud%20Services&component=Server%3A%20Remote%20Settings>`_ (Admin, permissions etc.)
 * Open a `Client Side ticket <https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox&component=Remote%20Settings%20Client>`_ (Gecko API related)
 
+Before reaching out in ``#delivery`` on Slack, double-check that your question wasn't already covered here.
+
 I cannot access my collection
 '''''''''''''''''''''''''''''
 
@@ -53,7 +55,7 @@ The **recommended way** to setup Firefox to pull data from STAGE is to use the `
 
 .. note::
 
-    On Beta and Release, you have to run Firefox with the environment variable ``MOZ_REMOTE_SETTINGS_DEVTOOLS=1`` to toggle environments. 
+    On Beta and Release, you have to run Firefox with the environment variable ``MOZ_REMOTE_SETTINGS_DEVTOOLS=1`` to toggle environments.
 
 Alternatively, in order to point STAGE before on fresh profiles for example, you can set the `appropriate preferences <https://github.com/mozilla/remote-settings-devtools/blob/1.7.0/extension/experiments/remotesettings/api.js#L173-L184>`_ in a ``user.js`` file:
 
@@ -72,9 +74,9 @@ The recommended way to setup Firefox to pull data from the preview collection is
 
 .. note::
 
-    On Beta and Release, you have to run Firefox with the environment variable ``MOZ_REMOTE_SETTINGS_DEVTOOLS=1`` to toggle environments. 
+    On Beta and Release, you have to run Firefox with the environment variable ``MOZ_REMOTE_SETTINGS_DEVTOOLS=1`` to toggle environments.
 
-See `developer docs about preview mode <https://firefox-source-docs.mozilla.org/services/settings/index.html#preview-mode>`_ for manual toggling. 
+See `developer docs about preview mode <https://firefox-source-docs.mozilla.org/services/settings/index.html#preview-mode>`_ for manual toggling.
 
 
 How do I preview the changes before requesting review?


### PR DESCRIPTION
Let's document our queries somewhere. 

This is related to `telemetry-query-examples` of our [Quality Standards](https://mozilla.github.io/syseng-pod/quality-standards/)


