### PR TITLE
Fix authors string in pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ down:  ## Shutwdown all containers
 
 install-docs: $(VENV)/bin/python $(DOC_STAMP)  ## Install documentation build dependencies
 $(DOC_STAMP): poetry.lock
-	POETRY_VIRTUALENVS_IN_PROJECT=1 poetry install --only docs
+	POETRY_VIRTUALENVS_IN_PROJECT=1 poetry install --no-root --only docs
 	touch $(DOC_STAMP)
 
 docs: install-docs  ## Build documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ asyncio_mode = "strict"
 name = "remote-settings"
 version = "0"
 description = "Easily manage evergreen settings data in Firefox"
-authors = ["@mozilla/remote-settings-reviewers"]
+authors = ["Contactless <postmaster@localhost>"]
 license = "MPL"
 readme = "README.rst"
 


### PR DESCRIPTION
Pull-requests like #492 or #493 fail because the authors string isn't an email 🤷 

We don't have an official contact email, so at least let's be clear.