### PR TITLE
Adding wait for browser tests

### DIFF
--- a/tests/browser_test.py
+++ b/tests/browser_test.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 from kinto_http.patch_type import JSONPatch
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
@@ -64,6 +65,8 @@ async def test_review_signoff(
         + f"#/buckets/{source_bucket}/collections/{source_collection}/simple-review"
     )
     selenium.refresh()
+    
+    time.sleep(1)  # give react a second for hooks
 
     try:
         approve_button: WebElement = selenium.find_element(

--- a/tests/browser_test.py
+++ b/tests/browser_test.py
@@ -1,5 +1,6 @@
-import pytest
 import time
+
+import pytest
 from kinto_http.patch_type import JSONPatch
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
@@ -65,7 +66,7 @@ async def test_review_signoff(
         + f"#/buckets/{source_bucket}/collections/{source_collection}/simple-review"
     )
     selenium.refresh()
-    
+
     time.sleep(1)  # give react a second for hooks
 
     try:


### PR DESCRIPTION
Adding a 1 second wait to browser tests to wait for hooks to finish running.
Not 100% sure why this is an intermittent issue as I cannot reproduce the problem in my browser and reproducing locally was very difficult. Inspecting the DOM shows nothing is actually changing so likely hook state.