### PR TITLE
Add Action workflow to bump Kinto Admin

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -1,10 +1,8 @@
 name: Run scheduled jobs
 
-# on:
-#   schedule:
-#     - cron: '0 0 * * *' # Runs daily at midnight
-
-on: workflow_dispatch
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight
 
 jobs:
   update-kinto-admin:
@@ -47,7 +45,7 @@ jobs:
           fi
 
       - name: Configure git
-        if: ${{ steps.compare_versions.outputs.update_needed == 'true' }}
+        if: ${{ steps.compare_versions.outputs.update_needed }}
         # https://github.com/orgs/community/discussions/26560
         run: |
           git config user.name github-actions[bot]
@@ -55,7 +53,7 @@ jobs:
 
       - name: Create branch
         id: create_branch
-        if: ${{ steps.compare_versions.outputs.update_needed == 'true' }}
+        if: ${{ steps.compare_versions.outputs.update_needed }}
         env:
           BRANCH_NAME: kinto-admin/${{ steps.latest_release_version.outputs.version }}
           LATEST_RELEASE: ${{ steps.latest_release_version.outputs.version }}

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Get latest release version
         id: latest_release_version
         run: |
-          LATEST_RELEASE_VERSION=$(curl -s https://api.github.com/repos/Kinto/kinto-admin/releases/latest | jq .tag_name | tr -d '"')
+          LATEST_RELEASE_VERSION=$(curl -s https://api.github.com/repos/Kinto/kinto-admin/releases/latest | jq -r .tag_name)
           echo "Latest Version: $LATEST_RELEASE_VERSION"
           echo "version=${LATEST_RELEASE_VERSION#v}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -1,0 +1,87 @@
+name: Run scheduled jobs
+
+# on:
+#   schedule:
+#     - cron: '0 0 * * *' # Runs daily at midnight
+
+on: workflow_dispatch
+
+jobs:
+  update-kinto-admin:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get current version
+        id: current_rs_version
+        run: |
+          CURRENT_RS_VERSION=$(cat kinto-admin/VERSION)
+          echo "Current Version: $CURRENT_RS_VERSION"
+          echo "version=$CURRENT_RS_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Get latest release version
+        id: latest_release_version
+        run: |
+          LATEST_RELEASE_VERSION=$(curl -s https://api.github.com/repos/Kinto/kinto-admin/releases/latest | jq .tag_name | tr -d '"')
+          echo "Latest Version: $LATEST_RELEASE_VERSION"
+          echo "version=${LATEST_RELEASE_VERSION#v}" >> $GITHUB_OUTPUT
+
+      - name: Compare versions
+        id: compare_versions
+        env:
+          LATEST_RELEASE_VERSION: ${{ steps.latest_release_version.outputs.version }}
+          CURRENT_RS_VERSION: ${{ steps.current_rs_version.outputs.version }}
+        run: |          
+          LATEST_VERSION=$(npx --yes semver "$CURRENT_RS_VERSION" "$LATEST_RELEASE_VERSION" | tail -n 1)
+          if [ "$LATEST_VERSION" != "$CURRENT_RS_VERSION" ]; then 
+            echo "Kinto Admin update ready"
+            echo "update_needed=true" >> $GITHUB_OUTPUT
+          else
+            echo "Kinto Admin up to date"
+            echo "update_needed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure git
+        if: ${{ steps.compare_versions.outputs.update_needed == 'true' }}
+        # https://github.com/orgs/community/discussions/26560
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+
+      - name: Create branch
+        id: create_branch
+        if: ${{ steps.compare_versions.outputs.update_needed == 'true' }}
+        env:
+          BRANCH_NAME: kinto-admin/${{ steps.latest_release_version.outputs.version }}
+          LATEST_RELEASE: ${{ steps.latest_release_version.outputs.version }}
+        run: |
+          git fetch origin --no-tags --quiet 'refs/heads/kinto-admin/*:refs/remotes/origin/kinto-admin/*'
+          
+          if [ "$(git rev-parse --quiet --verify origin/$BRANCH_NAME)" ]; then
+            echo "Branch $BRANCH_NAME already exists on origin."
+            echo "pr_needed=false" >> $GITHUB_OUTPUT
+          else
+            git checkout -b "$BRANCH_NAME"
+            echo "$LATEST_RELEASE" > kinto-admin/VERSION        
+            git commit -am "Update Kinto Admin to $LATEST_RELEASE"
+            git push origin $BRANCH_NAME
+            echo "pr_needed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create pull request
+        if: ${{ steps.compare_versions.outputs.update_needed == 'true' && steps.create_branch.outputs.pr_needed == 'true'}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: kinto-admin/${{ steps.latest_release_version.outputs.version }}
+        run: |
+          gh pr create \
+            --title "Update Kinto Admin version to ${{ steps.latest_release_version.outputs.version }}" \
+            --body "" \
+            --base "main" \
+            --head "$BRANCH_NAME" \
+            --label "dependencies"

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -55,10 +55,10 @@ jobs:
         id: create_branch
         if: ${{ steps.compare_versions.outputs.update_needed == 'true' }}
         env:
-          BRANCH_NAME: kinto-admin/${{ steps.latest_release_version.outputs.version }}
+          BRANCH_NAME: updates/kinto-admin-${{ steps.latest_release_version.outputs.version }}
           LATEST_RELEASE: ${{ steps.latest_release_version.outputs.version }}
         run: |
-          git fetch origin --no-tags --quiet 'refs/heads/kinto-admin/*:refs/remotes/origin/kinto-admin/*'
+          git fetch origin --no-tags --quiet 'refs/heads/updates/*:refs/remotes/origin/updates/*'
           
           if [ "$(git rev-parse --quiet --verify origin/$BRANCH_NAME)" ]; then
             echo "Branch $BRANCH_NAME already exists on origin."
@@ -75,7 +75,7 @@ jobs:
         if: ${{ steps.compare_versions.outputs.update_needed == 'true' && steps.create_branch.outputs.pr_needed == 'true'}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH_NAME: kinto-admin/${{ steps.latest_release_version.outputs.version }}
+          BRANCH_NAME: updates/kinto-admin-${{ steps.latest_release_version.outputs.version }}
         run: |
           gh pr create \
             --title "Update Kinto Admin version to ${{ steps.latest_release_version.outputs.version }}" \

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -45,7 +45,7 @@ jobs:
           fi
 
       - name: Configure git
-        if: ${{ steps.compare_versions.outputs.update_needed }}
+        if: ${{ steps.compare_versions.outputs.update_needed == 'true' }}
         # https://github.com/orgs/community/discussions/26560
         run: |
           git config user.name github-actions[bot]
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create branch
         id: create_branch
-        if: ${{ steps.compare_versions.outputs.update_needed }}
+        if: ${{ steps.compare_versions.outputs.update_needed == 'true' }}
         env:
           BRANCH_NAME: kinto-admin/${{ steps.latest_release_version.outputs.version }}
           LATEST_RELEASE: ${{ steps.latest_release_version.outputs.version }}


### PR DESCRIPTION
Adds a workflow to automatically bump https://github.com/mozilla/remote-settings/blob/main/kinto-admin/VERSION when a new version of [Kinto Admin](https://github.com/Kinto/kinto-admin) is released.

This was more code that was expected -- happy for suggestions to make this more concise.


Here are some example runs:

- version was updated, creates a PR: https://github.com/grahamalama/remote-settings/actions/runs/7587922591/job/20669367084
- the branch already exists, so skips creating the PR: https://github.com/grahamalama/remote-settings/actions/runs/7587945169/job/20669406207
- Kinto Admin is up to date: https://github.com/grahamalama/remote-settings/actions/runs/7588102152/job/20669901216