### PR TITLE
Fixes #522 - Replacing selenium test with simple playwright test

### DIFF
--- a/IntegrationTests.Dockerfile
+++ b/IntegrationTests.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.1-slim as build
+FROM python:3.12.1 as build
 
 ENV PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
@@ -17,7 +17,9 @@ WORKDIR /opt
 COPY pyproject.toml poetry.lock ./
 RUN $POETRY_HOME/bin/poetry install --only integration-tests --no-root
 
-FROM python:3.12.1-slim
+FROM python:3.12.1
+RUN apt update && apt upgrade -y
+
 ENV PATH="/opt/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1 \
     VIRTUAL_ENV=/opt/.venv \
@@ -27,6 +29,9 @@ COPY /bin/update_and_install_system_packages.sh /opt
 RUN /opt/update_and_install_system_packages.sh wget
 
 COPY --from=build $VIRTUAL_ENV $VIRTUAL_ENV
+
+RUN playwright install firefox
+RUN playwright install-deps
 
 WORKDIR /app
 COPY tests/ pyproject.toml ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - web
       - certchains
     environment:
-      - SERVER=http://web:8888/v1/
+      - SERVER=http://web:8888/v1
       - MAIL_DIR=/var/debug-mail/
     volumes:
       - debug-mail:/var/debug-mail/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,15 +37,6 @@ services:
     ports:
       - 9999:80
 
-  selenium:
-    image: selenium/standalone-firefox
-    profiles: [integration-test]
-    volumes:
-      - /dev/shm:/dev/shm
-    ports:
-      - 4444:4444
-    shm_size: 2g
-
   web:
     build:
       dockerfile: RemoteSettings.Dockerfile
@@ -79,12 +70,9 @@ services:
     profiles: [integration-test]
     depends_on:
       - web
-      - selenium
       - certchains
     environment:
-      - SERVER=http://web:8888/v1
-      - SELENIUM_HOST=selenium
-      - SELENIUM_PORT=4444
+      - SERVER=http://web:8888/v1/
       - MAIL_DIR=/var/debug-mail/
     volumes:
       - debug-mail:/var/debug-mail/

--- a/poetry.lock
+++ b/poetry.lock
@@ -1149,17 +1149,6 @@ docs = ["Sphinx", "furo"]
 test = ["objgraph", "psutil"]
 
 [[package]]
-name = "h11"
-version = "0.14.0"
-description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
-    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
-]
-
-[[package]]
 name = "httpie"
 version = "3.2.2"
 description = "HTTPie: modern, user-friendly command-line HTTP client for the API era."
@@ -1366,7 +1355,7 @@ memcached = ["python-memcached"]
 monitoring = ["newrelic", "sentry-sdk[sqlalchemy]", "statsd", "werkzeug"]
 postgresql = ["SQLAlchemy (<3)", "psycopg2", "zope.sqlalchemy"]
 redis = ["kinto-redis"]
-test = ["bravado", "pytest", "pytest-cache", "pytest-cov", "selenium", "webtest"]
+test = ["bravado", "pytest", "pytest-cache", "pytest-cov", "webtest"]
 
 [[package]]
 name = "kinto-attachment"
@@ -1713,20 +1702,6 @@ files = [
 infinite-tracing = ["grpcio", "protobuf"]
 
 [[package]]
-name = "outcome"
-version = "1.3.0.post0"
-description = "Capture the outcome of Python function calls."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b"},
-    {file = "outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8"},
-]
-
-[package.dependencies]
-attrs = ">=19.2.0"
-
-[[package]]
 name = "packaging"
 version = "23.2"
 description = "Core utilities for Python packages"
@@ -1796,6 +1771,26 @@ plaster = ">=0.5"
 
 [package.extras]
 testing = ["pytest", "pytest-cov"]
+
+[[package]]
+name = "playwright"
+version = "1.41.1"
+description = "A high-level API to automate web browsers"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "playwright-1.41.1-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:b456f25db38e4d93afc3c671e1093f3995afb374f14cee284152a30f84cfff02"},
+    {file = "playwright-1.41.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53ff152506dbd8527aa815e92757be72f5df60810e8000e9419d29fd4445f53c"},
+    {file = "playwright-1.41.1-py3-none-macosx_11_0_universal2.whl", hash = "sha256:70c432887b8b5e896fa804fb90ca2c8baf05b13a3590fb8bce8b3c3efba2842d"},
+    {file = "playwright-1.41.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:f227a8d616fd3a02d45d68546ee69947dce4a058df134a9e7dc6167c543de3cd"},
+    {file = "playwright-1.41.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:475130f879b4ba38b9db7232a043dd5bc3a8bd1a84567fbea7e21a02ee2fcb13"},
+    {file = "playwright-1.41.1-py3-none-win32.whl", hash = "sha256:ef769414ea0ceb76085c67812ab6bc0cc6fac0adfc45aaa09d54ee161d7f637b"},
+    {file = "playwright-1.41.1-py3-none-win_amd64.whl", hash = "sha256:316e1ba0854a712e9288b3fe49509438e648d43bade77bf724899de8c24848de"},
+]
+
+[package.dependencies]
+greenlet = "3.0.3"
+pyee = "11.0.1"
 
 [[package]]
 name = "pluggy"
@@ -1889,6 +1884,23 @@ files = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
+
+[[package]]
+name = "pyee"
+version = "11.0.1"
+description = "A rough port of Node.js's EventEmitter to Python with a few tricks of its own"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyee-11.0.1-py3-none-any.whl", hash = "sha256:9bcc9647822234f42c228d88de63d0f9ffa881e87a87f9d36ddf5211f6ac977d"},
+    {file = "pyee-11.0.1.tar.gz", hash = "sha256:a642c51e3885a33ead087286e35212783a4e9b8d6514a10a5db4e57ac57b2b29"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+
+[package.extras]
+dev = ["black", "flake8", "flake8-black", "isort", "jupyter-console", "mkdocs", "mkdocs-include-markdown-plugin", "mkdocstrings[python]", "pytest", "pytest-asyncio", "pytest-trio", "toml", "tox", "trio", "trio", "trio-typing", "twine", "twisted", "validate-pyproject[all]"]
 
 [[package]]
 name = "pygments"
@@ -2072,85 +2084,21 @@ requests = ">=2.9"
 test = ["black (>=22.1.0)", "flake8 (>=4.0.1)", "pre-commit (>=2.17.0)", "pytest-localserver (>=0.7.1)", "tox (>=3.24.5)"]
 
 [[package]]
-name = "pytest-html"
-version = "4.1.1"
-description = "pytest plugin for generating HTML reports"
+name = "pytest-playwright"
+version = "0.4.4"
+description = "A pytest wrapper with fixtures for Playwright to automate web browsers"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest_html-4.1.1-py3-none-any.whl", hash = "sha256:c8152cea03bd4e9bee6d525573b67bbc6622967b72b9628dda0ea3e2a0b5dd71"},
-    {file = "pytest_html-4.1.1.tar.gz", hash = "sha256:70a01e8ae5800f4a074b56a4cb1025c8f4f9b038bba5fe31e3c98eb996686f07"},
+    {file = "pytest-playwright-0.4.4.tar.gz", hash = "sha256:5488db4cc49028491c5130af0a2bb6b1d0b222a202217f6d14491d4c9aa67ff9"},
+    {file = "pytest_playwright-0.4.4-py3-none-any.whl", hash = "sha256:df306f3a60a8631a3cfde1b95a2ed5a89203a3408dfa1154de049ca7de87c90b"},
 ]
 
 [package.dependencies]
-jinja2 = ">=3.0.0"
-pytest = ">=7.0.0"
-pytest-metadata = ">=2.0.0"
-
-[package.extras]
-docs = ["pip-tools (>=6.13.0)"]
-test = ["assertpy (>=1.1)", "beautifulsoup4 (>=4.11.1)", "black (>=22.1.0)", "flake8 (>=4.0.1)", "pre-commit (>=2.17.0)", "pytest-mock (>=3.7.0)", "pytest-rerunfailures (>=11.1.2)", "pytest-xdist (>=2.4.0)", "selenium (>=4.3.0)", "tox (>=3.24.5)"]
-
-[[package]]
-name = "pytest-metadata"
-version = "3.1.0"
-description = "pytest plugin for test session metadata"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pytest_metadata-3.1.0-py3-none-any.whl", hash = "sha256:54ce21108708d0f2fdb30c7056ce5789ce052262efff4832892aa92df4a76291"},
-    {file = "pytest_metadata-3.1.0.tar.gz", hash = "sha256:53dcd8bbd101cf6ca97efb4a42a72fcbee5de173bddad4850f4ce9bb27e9f0f2"},
-]
-
-[package.dependencies]
-pytest = ">=7.0.0"
-
-[package.extras]
-test = ["black (>=22.1.0)", "flake8 (>=4.0.1)", "pre-commit (>=2.17.0)", "tox (>=3.24.5)"]
-
-[[package]]
-name = "pytest-selenium"
-version = "4.1.0"
-description = "pytest plugin for Selenium"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pytest_selenium-4.1.0-py3-none-any.whl", hash = "sha256:c6f2c18e91596d3ef360d74c450953767a15193879d3971296498151d1843c01"},
-    {file = "pytest_selenium-4.1.0.tar.gz", hash = "sha256:b0a4e1f27750cde631c513c87ae4863dcf9e180e5a1d680a66077da8a669156c"},
-]
-
-[package.dependencies]
-pytest = ">=6.0.0"
-pytest-base-url = ">=2.0.0"
-pytest-html = ">=4.0.0"
-pytest-variables = ">=2.0.0"
-requests = ">=2.26.0"
-selenium = ">=4.10.0"
-tenacity = ">=6.0.0"
-
-[package.extras]
-appium = ["appium-python-client (>=1.0.0)"]
-test = ["black (>=22.1.0)", "flake8 (>=4.0.1)", "pre-commit (>=2.17.0)", "pytest-mock (>=3.6.1)", "pytest-xdist (>=2.4.0)", "tox (>=3.24.5)"]
-
-[[package]]
-name = "pytest-variables"
-version = "3.1.0"
-description = "pytest plugin for providing variables to tests/fixtures"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pytest_variables-3.1.0-py3-none-any.whl", hash = "sha256:4c864d2b7093f9053a2bed61e4b1d027bb26456924e637fcef2d1455d32732b1"},
-    {file = "pytest_variables-3.1.0.tar.gz", hash = "sha256:4719b07f0f6e5d07829b19284a99d9159543a2e0336311f7bc4ee3b1617f595d"},
-]
-
-[package.dependencies]
-pytest = ">=7.0.0"
-
-[package.extras]
-hjson = ["hjson"]
-test = ["black (>=22.1.0)", "flake8 (>=4.0.1)", "pre-commit (>=2.17.0)", "tox (>=3.24.5)"]
-toml = ["toml"]
-yaml = ["pyyaml"]
+playwright = ">=1.18"
+pytest = ">=6.2.4,<9.0.0"
+pytest-base-url = ">=1.0.0,<3.0.0"
+python-slugify = ">=6.0.0,<9.0.0"
 
 [[package]]
 name = "python-dateutil"
@@ -2246,6 +2194,23 @@ files = [
     {file = "python_rapidjson-1.14-cp39-cp39-win32.whl", hash = "sha256:bf432624e462a9942e384d3c954d3085530765cedb72c877fd110f6eca5528e5"},
     {file = "python_rapidjson-1.14-cp39-cp39-win_amd64.whl", hash = "sha256:f827fc652ab51e3777b375d17867132351eb9b4e53578a139c24fb5c559fdb45"},
 ]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.3"
+description = "A Python slugify application that also handles Unicode"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "python-slugify-8.0.3.tar.gz", hash = "sha256:e04cba5f1c562502a1175c84a8bc23890c54cdaf23fccaaf0bf78511508cabed"},
+    {file = "python_slugify-8.0.3-py2.py3-none-any.whl", hash = "sha256:c71189c161e8c671f1b141034d9a56308a8a5978cd13d40446c879569212fdd1"},
+]
+
+[package.dependencies]
+text-unidecode = ">=1.3"
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
 name = "pyyaml"
@@ -2560,24 +2525,6 @@ files = [
 ]
 
 [[package]]
-name = "selenium"
-version = "4.17.2"
-description = ""
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "selenium-4.17.2-py3-none-any.whl", hash = "sha256:5aee79026c07985dc1b0c909f34084aa996dfe5b307602de9016d7a621a473f2"},
-    {file = "selenium-4.17.2.tar.gz", hash = "sha256:d43d6972e516855fb242ef9ce4ce759057b115070e702e7b1c1032fe7b38d87b"},
-]
-
-[package.dependencies]
-certifi = ">=2021.10.8"
-trio = ">=0.17,<1.0"
-trio-websocket = ">=0.9,<1.0"
-typing_extensions = ">=4.9.0"
-urllib3 = {version = ">=1.26,<3", extras = ["socks"]}
-
-[[package]]
 name = "sentry-sdk"
 version = "1.40.0"
 description = "Python client for Sentry (https://sentry.io)"
@@ -2651,17 +2598,6 @@ files = [
 ]
 
 [[package]]
-name = "sniffio"
-version = "1.3.0"
-description = "Sniff out which async library your code is running under"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "sniffio-1.3.0-py3-none-any.whl", hash = "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"},
-    {file = "sniffio-1.3.0.tar.gz", hash = "sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101"},
-]
-
-[[package]]
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
@@ -2670,17 +2606,6 @@ python-versions = "*"
 files = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
-]
-
-[[package]]
-name = "sortedcontainers"
-version = "2.4.0"
-description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
-optional = false
-python-versions = "*"
-files = [
-    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
-    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 
 [[package]]
@@ -2921,18 +2846,15 @@ files = [
 ]
 
 [[package]]
-name = "tenacity"
-version = "8.2.3"
-description = "Retry code until it succeeds"
+name = "text-unidecode"
+version = "1.3"
+description = "The most basic Text::Unidecode port"
 optional = false
-python-versions = ">=3.7"
+python-versions = "*"
 files = [
-    {file = "tenacity-8.2.3-py3-none-any.whl", hash = "sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c"},
-    {file = "tenacity-8.2.3.tar.gz", hash = "sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a"},
+    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
+    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
 ]
-
-[package.extras]
-doc = ["reno", "sphinx", "tornado (>=4.5)"]
 
 [[package]]
 name = "transaction"
@@ -2967,40 +2889,6 @@ files = [
 docs = ["Sphinx (>=1.3.1)", "docutils", "pylons-sphinx-themes"]
 
 [[package]]
-name = "trio"
-version = "0.24.0"
-description = "A friendly Python library for async concurrency and I/O"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "trio-0.24.0-py3-none-any.whl", hash = "sha256:c3bd3a4e3e3025cd9a2241eae75637c43fe0b9e88b4c97b9161a55b9e54cd72c"},
-    {file = "trio-0.24.0.tar.gz", hash = "sha256:ffa09a74a6bf81b84f8613909fb0beaee84757450183a7a2e0b47b455c0cac5d"},
-]
-
-[package.dependencies]
-attrs = ">=20.1.0"
-cffi = {version = ">=1.14", markers = "os_name == \"nt\" and implementation_name != \"pypy\""}
-idna = "*"
-outcome = "*"
-sniffio = ">=1.3.0"
-sortedcontainers = "*"
-
-[[package]]
-name = "trio-websocket"
-version = "0.11.1"
-description = "WebSocket library for Trio"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "trio-websocket-0.11.1.tar.gz", hash = "sha256:18c11793647703c158b1f6e62de638acada927344d534e3c7628eedcb746839f"},
-    {file = "trio_websocket-0.11.1-py3-none-any.whl", hash = "sha256:520d046b0d030cf970b8b2b2e00c4c2245b3807853ecd44214acd33d74581638"},
-]
-
-[package.dependencies]
-trio = ">=0.11"
-wsproto = ">=0.14"
-
-[[package]]
 name = "typing-extensions"
 version = "4.9.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -3032,9 +2920,6 @@ files = [
     {file = "urllib3-2.2.0-py3-none-any.whl", hash = "sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"},
     {file = "urllib3-2.2.0.tar.gz", hash = "sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20"},
 ]
-
-[package.dependencies]
-pysocks = {version = ">=1.5.6,<1.5.7 || >1.5.7,<2.0", optional = true, markers = "extra == \"socks\""}
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
@@ -3133,20 +3018,6 @@ MarkupSafe = ">=2.1.1"
 
 [package.extras]
 watchdog = ["watchdog (>=2.3)"]
-
-[[package]]
-name = "wsproto"
-version = "1.2.0"
-description = "WebSockets state-machine based protocol implementation"
-optional = false
-python-versions = ">=3.7.0"
-files = [
-    {file = "wsproto-1.2.0-py3-none-any.whl", hash = "sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736"},
-    {file = "wsproto-1.2.0.tar.gz", hash = "sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065"},
-]
-
-[package.dependencies]
-h11 = ">=0.9.0,<1"
 
 [[package]]
 name = "yarl"
@@ -3346,4 +3217,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11, <3.13"
-content-hash = "ed37792dcac86b227f90b614ff9eba1444eb7e91e8e9bab13760d0c8de06afe4"
+content-hash = "761183149ebf49c34222761d17ef3202fb1ff866c3ff30230b1c2a1b1d48f150"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,8 +101,9 @@ httpie = "3.2.2"
 kinto-http = "11.0.1"
 pytest = "7.4.4"
 pytest-asyncio = "0.23.4"
-pytest-selenium = "4.1.0"
 webtest = "3.0.0"
+playwright = "^1.41.1"
+pytest-playwright = "^0.4.4"
 
 [tool.poetry.group.docs]
 optional = true

--- a/tests/browser_test.py
+++ b/tests/browser_test.py
@@ -1,61 +1,92 @@
 import os
 import re
-import unittest
+import pytest
+from playwright.sync_api import expect
+from kinto_http.patch_type import JSONPatch
 
-from playwright.sync_api import expect, sync_playwright
+@pytest.fixture(autouse=True)
+def do_setup(
+    source_bucket, 
+    source_collection,
+    setup_auth,
+    skip_server_setup,
+    keep_existing,
+    editor_auth,
+    reviewer_auth,
+    make_client
+):
+    if skip_server_setup:
+        return
+    
+    editor_client = make_client(editor_auth)
+    reviewer_client = make_client(reviewer_auth)
+
+    editor_id = editor_client.server_info()["user"]["id"]
+    reviewer_id = reviewer_client.server_info()["user"]["id"]
+
+    setup_client = make_client(setup_auth)
+    setup_client.create_bucket(if_not_exists=True)
+    setup_client.create_collection(
+        permissions={"write": [editor_id, reviewer_id]},
+        if_not_exists=True,
+    )
+    data = JSONPatch([{"op": "add", "path": "/data/members/0", "value": editor_id}])
+    setup_client.patch_group(id=f"{source_collection}-editors", changes=data)
+    data = JSONPatch(
+        [{"op": "add", "path": "/data/members/0", "value": reviewer_id}]
+    )
+    setup_client.patch_group(
+        id=f"{source_collection}-reviewers", changes=data
+    )
+    if not keep_existing:
+        setup_client.delete_records()
 
 
-baseUrl = os.getenv("SERVER", "http://localhost:8888/v1")
-auth = {"user": "user", "password": "pass"}
+def test_login_and_submit_review(
+    server, 
+    page, 
+    editor_auth, 
+    source_bucket, 
+    source_collection,
+    setup_auth,
+    skip_server_setup,
+    keep_existing
+):
+    # load login page
+    page.goto(f"{server}/admin/")
+    expect(page).to_have_title(re.compile("Remote Settings"))
 
-browser = sync_playwright().start().firefox.launch()
-context = browser.new_context(base_url=baseUrl)
-page = browser.new_page()
+    # login
+    page.get_by_label("Kinto Account Auth").click()
+    txtUsername = page.get_by_label(re.compile("Username"))
+    txtPassword = page.get_by_label(re.compile("Password"))
+    txtUsername.fill(editor_auth[0])
+    txtPassword.fill(editor_auth[1])
+    page.get_by_text(re.compile("Sign in using Kinto Account Auth")).click()
 
+    # verify home page loaded
+    expect(page.get_by_text("project_name")).to_be_visible()
+    expect(page.get_by_text("project_version")).to_be_visible()
+    expect(page.get_by_text("http_api_version")).to_be_visible()
+    expect(page.get_by_text("project_docs")).to_be_visible()
 
-class BrowserTest(unittest.TestCase):
-    def setUp(self):
-        request = context.request
-        request.post(
-            "accounts",
-            data={"data": {"id": auth["user"], "password": auth["password"]}},
-        )
+    # navigate to test collection
+    page.click('[href="#/buckets/main-workspace/collections/integration-tests/records"]')
+    expect(page.get_by_text("Records of main-workspace/integration-tests")).to_be_visible()
+    
+    # create a record
+    page.get_by_text("Create record").first.click()
+    page.get_by_label("JSON record").fill('{"prop": "val"}');
+    page.get_by_text("Create record").click()
 
-    def test_login_and_submit_review(self):
-        # load login page
-        page.goto(f"{baseUrl}/admin/")
-        expect(page).to_have_title(re.compile("Remote Settings"))
+    # request a review
+    page.get_by_text("Request review...").first.click()
+    page.get_by_placeholder("Comment...").last.fill("Review comment")
+    page.get_by_text("Request review").last.click()
 
-        # login
-        page.get_by_label("Kinto Account Auth").click()
-        txtUsername = page.get_by_label(re.compile("Username"))
-        txtPassword = page.get_by_label(re.compile("Password"))
-        txtUsername.fill(auth["user"])
-        txtPassword.fill(auth["password"])
-        page.get_by_text(re.compile("Sign in using Kinto Account Auth")).click()
+    # verify that we are in-progress for review
+    expect(page.locator(".bs-wizard-step.complete").first).to_contain_text("Work in progress")
+    expect(page.locator(".bs-wizard-step.active").first).to_contain_text("Waiting review")
+    expect(page.locator(".bs-wizard-step.disabled").first).to_contain_text("Approved")
 
-        # verify home page loaded
-        expect(page.get_by_text("project_name")).to_be_visible()
-        expect(page.get_by_text("project_version")).to_be_visible()
-        expect(page.get_by_text("http_api_version")).to_be_visible()
-        expect(page.get_by_text("project_docs")).to_be_visible()
-
-        # navigate to test collection
-        page.click('[href="#/buckets/main-workspace/collections/integration-tests/records"]')
-        expect(page.get_by_text("Records of main-workspace/integration-tests")).to_be_visible()
-        
-        # create a record
-        page.get_by_text("Create record").first.click()
-        page.get_by_label("JSON record").fill('{"prop": "val"}');
-        page.get_by_text("Create record").click()
-
-        # request a review
-        page.get_by_text("Request review...").first.click()
-        page.get_by_placeholder("Comment...").last.fill("Review comment")
-        page.get_by_text("Request review").last.click()
-
-        # verify that we are in-progress for review
-        expect(page.locator(".bs-wizard-step.complete").first).to_contain_text("Work in progress")
-        expect(page.locator(".bs-wizard-step.active").first).to_contain_text("Waiting review")
-        expect(page.locator(".bs-wizard-step.disabled").first).to_contain_text("Approved")
-
+# TODO: reviewer test scenario - login to approve pending request

--- a/tests/browser_test.py
+++ b/tests/browser_test.py
@@ -1,168 +1,35 @@
-import time
+import re
+import os
+import unittest
+from playwright.sync_api import expect, sync_playwright
 
-import pytest
-from kinto_http.patch_type import JSONPatch
-from selenium.common.exceptions import NoSuchElementException
-from selenium.webdriver.common.by import By
-from selenium.webdriver.remote.webdriver import WebDriver
-from selenium.webdriver.remote.webelement import WebElement
+baseUrl = os.getenv("SERVER", "http://localhost:8888/v1/")
+auth = {"user": "user", "password": "pass"}
 
-from .conftest import Auth, ClientFactory, signed_resource
+browser = sync_playwright().start().firefox.launch()
+context = browser.new_context(base_url=baseUrl)
+page = browser.new_page()
 
+class BrowserTest(unittest.TestCase):
+    def setUp(self):
+        request = context.request
+        request.post("accounts", data={"data": {"id": auth["user"], "password": auth["password"]}})
+        
+    def test_login_and_view_home_page(self):
+        page.goto(f"{baseUrl}admin/")
 
-pytestmark = pytest.mark.asyncio
+        expect(page).to_have_title(re.compile("Remote Settings"))
 
+        page.get_by_label("Kinto Account Auth").click()
+        txtUsername = page.get_by_label(re.compile("Username"))
+        txtPassword = page.get_by_label(re.compile("Password"))
 
-async def test_review_signoff(
-    base_url: str,
-    selenium: WebDriver,
-    make_client: ClientFactory,
-    setup_auth: Auth,
-    editor_auth: Auth,
-    reviewer_auth: Auth,
-    source_bucket: str,
-    source_collection: str,
-    skip_server_setup: bool,
-    keep_existing: bool,
-):
-    editor_client = make_client(editor_auth)
-    reviewer_client = make_client(reviewer_auth)
+        txtUsername.fill(auth["user"])
+        txtPassword.fill(auth["password"])
+        page.get_by_text(re.compile("Sign in using Kinto Account Auth")).click()
 
-    editor_id = (await editor_client.server_info())["user"]["id"]
-    reviewer_id = (await reviewer_client.server_info())["user"]["id"]
-
-    # Setup remote server.
-    if not skip_server_setup:
-        setup_client = make_client(setup_auth)
-        await setup_client.create_bucket(if_not_exists=True)
-        await setup_client.create_collection(
-            permissions={"write": [editor_id, reviewer_id]},
-            if_not_exists=True,
-        )
-        data = JSONPatch([{"op": "add", "path": "/data/members/0", "value": editor_id}])
-        await setup_client.patch_group(id=f"{source_collection}-editors", changes=data)
-        data = JSONPatch(
-            [{"op": "add", "path": "/data/members/0", "value": reviewer_id}]
-        )
-        await setup_client.patch_group(
-            id=f"{source_collection}-reviewers", changes=data
-        )
-        if not keep_existing:
-            await setup_client.delete_records()
-
-    dest_bucket = (await signed_resource(editor_client))["destination"]["bucket"]
-
-    # Sample data.
-    await editor_client.create_record(data={"testing": 123})
-    await editor_client.patch_collection(data={"status": "to-review"})
-
-    # Start browsing.
-    selenium.get(base_url)
-
-    sign_in(selenium, reviewer_auth)
-
-    selenium.get(
-        base_url
-        + f"#/buckets/{source_bucket}/collections/{source_collection}/simple-review"
-    )
-    selenium.refresh()
-
-    time.sleep(1)  # give react a second for hooks
-
-    try:
-        approve_button: WebElement = selenium.find_element(
-            By.XPATH, "//button[contains(., 'Approve')]"
-        )
-    except NoSuchElementException:
-        print(selenium.page_source)  # CI debugging.
-        raise
-
-    assert approve_button, "Approve button not found"
-    assert approve_button.text == "Approve..."
-    assert approve_button.is_displayed()
-
-    reject_button: WebElement = selenium.find_element(
-        By.XPATH, "//button[contains(., 'Decline')]"
-    )
-    assert reject_button, "Reject button not found"
-    assert reject_button.text == "Decline..."
-    assert reject_button.is_displayed()
-
-    approve_button.click()
-
-    # find and click show readonly buckets/collections
-    readonly_checkbox: WebElement = selenium.find_element(By.ID, "read-only-toggle")
-    assert readonly_checkbox, "Readonly checkbox not found"
-    assert readonly_checkbox.is_displayed()
-    readonly_checkbox.click()
-
-    # find and click on main bucket `integration-tests` collection
-    product_integrity: WebElement = selenium.find_element(
-        By.XPATH,
-        f"//a[@href='#/buckets/{dest_bucket}/collections/{source_collection}/records' and contains(., '{source_collection}')]",
-    )
-    assert (
-        product_integrity
-    ), f"{source_collection} collection not found under {dest_bucket} bucket"
-    assert product_integrity.is_displayed()
-    product_integrity.click()
-
-    # find and ensure record was properly signed to destination bucket
-    data: WebElement = selenium.find_element(By.XPATH, "//code")
-    assert (
-        data
-    ), f"Record not found in {source_collection} collection under {dest_bucket} bucket"
-    assert data.is_displayed()
-    assert data.text == '{"testing":123}'
-
-
-def sign_in(selenium: WebDriver, auth: Auth):
-    # find and select Kinto Account Auth for login
-    kinto_auth_radio_button: WebElement = selenium.find_element(
-        By.XPATH, "//label[contains(.,'Kinto Account Auth')]"
-    )
-    assert kinto_auth_radio_button, "Kinto Account Auth radio button not found"
-    kinto_auth_radio_button.click()
-
-    # ensure account credentials fields render
-    account_creds_title: WebElement = selenium.find_element(
-        By.ID, "root_credentials__title"
-    )
-    assert account_creds_title, "Account credentials title not found"
-    assert account_creds_title.text == "Account credentials"
-    assert account_creds_title.is_displayed()
-
-    # enter login username
-    account_creds_user: WebElement = selenium.find_element(
-        By.ID, "root_credentials_username"
-    )
-    assert account_creds_user, "Account credentials username entry not found"
-    assert account_creds_user.is_displayed()
-    account_creds_user.send_keys(auth[0])
-
-    # enter login password
-    account_creds_pass: WebElement = selenium.find_element(
-        By.ID, "root_credentials_password"
-    )
-    assert account_creds_pass, "Account credentials password entry not found"
-    assert account_creds_pass.is_displayed()
-    account_creds_pass.send_keys(auth[1])
-
-    # sign in
-    sign_in_button: WebElement = selenium.find_element(By.CLASS_NAME, "btn-info")
-    assert sign_in_button, "Sign in button not found"
-    assert sign_in_button.text == "Sign in using Kinto Account Auth"
-    assert sign_in_button.is_displayed()
-    sign_in_button.click()
-
-    # determine if successfully logged in to admin home page
-    try:
-        server_info: WebElement = selenium.find_element(
-            By.XPATH,
-            "//div[@class='card-header' and contains(., 'Server information')]",
-        )
-        assert server_info, "Server information not found"
-        assert server_info.text == "Server information"
-        assert server_info.is_displayed()
-    except NoSuchElementException:
-        pytest.fail("Login was unsuccessful")
+        expect(page.get_by_text("Remote Settings")).to_be_visible()
+        expect(page.get_by_text("project_name")).to_be_visible()
+        expect(page.get_by_text("project_version")).to_be_visible()
+        expect(page.get_by_text("http_api_version")).to_be_visible()
+        expect(page.get_by_text("project_docs")).to_be_visible()

--- a/tests/browser_test.py
+++ b/tests/browser_test.py
@@ -5,7 +5,7 @@ import unittest
 from playwright.sync_api import expect, sync_playwright
 
 
-baseUrl = os.getenv("SERVER", "http://localhost:8888/v1/")
+baseUrl = os.getenv("SERVER", "http://localhost:8888/v1")
 auth = {"user": "user", "password": "pass"}
 
 browser = sync_playwright().start().firefox.launch()
@@ -22,7 +22,7 @@ class BrowserTest(unittest.TestCase):
         )
 
     def test_login_and_view_home_page(self):
-        page.goto(f"{baseUrl}admin/")
+        page.goto(f"{baseUrl}/admin/")
 
         expect(page).to_have_title(re.compile("Remote Settings"))
 
@@ -34,7 +34,6 @@ class BrowserTest(unittest.TestCase):
         txtPassword.fill(auth["password"])
         page.get_by_text(re.compile("Sign in using Kinto Account Auth")).click()
 
-        expect(page.get_by_text("Remote Settings")).to_be_visible()
         expect(page.get_by_text("project_name")).to_be_visible()
         expect(page.get_by_text("project_version")).to_be_visible()
         expect(page.get_by_text("http_api_version")).to_be_visible()

--- a/tests/browser_test.py
+++ b/tests/browser_test.py
@@ -1,7 +1,9 @@
-import re
 import os
+import re
 import unittest
+
 from playwright.sync_api import expect, sync_playwright
+
 
 baseUrl = os.getenv("SERVER", "http://localhost:8888/v1/")
 auth = {"user": "user", "password": "pass"}
@@ -10,11 +12,15 @@ browser = sync_playwright().start().firefox.launch()
 context = browser.new_context(base_url=baseUrl)
 page = browser.new_page()
 
+
 class BrowserTest(unittest.TestCase):
     def setUp(self):
         request = context.request
-        request.post("accounts", data={"data": {"id": auth["user"], "password": auth["password"]}})
-        
+        request.post(
+            "accounts",
+            data={"data": {"id": auth["user"], "password": auth["password"]}},
+        )
+
     def test_login_and_view_home_page(self):
         page.goto(f"{baseUrl}admin/")
 

--- a/tests/browser_test.py
+++ b/tests/browser_test.py
@@ -55,6 +55,7 @@ class BrowserTest(unittest.TestCase):
         page.get_by_text("Request review").last.click()
 
         # verify that we are in-progress for review
-        wizardSteps = page.locator(".bs-wizard-step")
-        expect(wizardSteps[0]).to_have_class("completed")
-        expect(wizardSteps[1]).to_have_class("active")
+        expect(page.locator(".bs-wizard-step.complete").first).to_contain_text("Work in progress")
+        expect(page.locator(".bs-wizard-step.active").first).to_contain_text("Waiting review")
+        expect(page.locator(".bs-wizard-step.disabled").first).to_contain_text("Approved")
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,6 @@ import pytest_asyncio
 import requests
 from kinto_http import AsyncClient, KintoException
 from requests.adapters import HTTPAdapter
-from selenium.webdriver.firefox.options import Options
-from selenium.webdriver.remote.webdriver import WebDriver
 from urllib3.util.retry import Retry
 
 
@@ -228,20 +226,6 @@ def _verify_url(request: pytest.FixtureRequest, base_url: str):
         retries = Retry(backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
         session.mount(base_url, HTTPAdapter(max_retries=retries))
         session.get(base_url, verify=False)
-
-
-@pytest.fixture()
-def firefox_options(firefox_options: Options) -> Options:
-    firefox_options.headless = True
-    return firefox_options
-
-
-@pytest.fixture()
-def selenium(selenium: WebDriver) -> WebDriver:
-    selenium.set_window_size(1024, 600)
-    selenium.maximize_window()
-    selenium.implicitly_wait(5)
-    return selenium
 
 
 def create_user(request_session: requests.Session, server: str, auth: Auth):

--- a/tests/integration/plugins/test_attachment.py
+++ b/tests/integration/plugins/test_attachment.py
@@ -16,17 +16,17 @@ async def test_attachment_plugin_new_record(
 ):
     if not skip_server_setup:
         setup_client = make_client(setup_auth)
-        await setup_server(setup_client)
+        setup_server(setup_client)
 
     editor_client = make_client(editor_auth)
     with open("kinto-logo.svg", "rb") as attachment:
         assert requests.post(
-            f"{editor_client.session.server_url}{await editor_client.get_endpoint('record', id='logo')}/attachment",
+            f"{editor_client.session.server_url}{editor_client.get_endpoint('record', id='logo')}/attachment",
             files={"attachment": attachment},
             auth=editor_client.session.auth,
         ), "Issue creating a new record with an attachment"
 
-    record = await editor_client.get_record(id="logo")
+    record = editor_client.get_record(id="logo")
 
     assert record
     assert "data" in record
@@ -41,10 +41,10 @@ async def test_attachment_plugin_existing_record(
 ):
     if not skip_server_setup:
         setup_client = make_client(setup_auth)
-        await setup_server(setup_client)
+        setup_server(setup_client)
 
     editor_client = make_client(editor_auth)
-    await editor_client.create_record(
+    editor_client.create_record(
         id="logo",
         data={"type": "logo"},
         if_not_exists=True,
@@ -52,12 +52,12 @@ async def test_attachment_plugin_existing_record(
 
     with open("kinto-logo.svg", "rb") as attachment:
         assert requests.post(
-            f"{editor_client.session.server_url}{await editor_client.get_endpoint('record', id='logo')}/attachment",
+            f"{editor_client.session.server_url}{editor_client.get_endpoint('record', id='logo')}/attachment",
             files={"attachment": attachment},
             auth=editor_client.session.auth,
         ), "Issue updating an existing record to include an attachment"
 
-    record = await editor_client.get_record(id="logo")
+    record = editor_client.get_record(id="logo")
 
     assert record
     assert "data" in record

--- a/tests/integration/plugins/test_changes.py
+++ b/tests/integration/plugins/test_changes.py
@@ -27,15 +27,15 @@ async def test_changes_plugin(
 ):
     if not skip_server_setup:
         setup_client = make_client(setup_auth)
-        await setup_server(setup_client)
+        setup_server(setup_client)
 
     anonymous_client = make_client(tuple())
     editor_client = make_client(editor_auth)
     reviewer_client = make_client(reviewer_auth)
 
     # 1. Inspect the content of monitor/changes to get some reference timestamp
-    records = await anonymous_client.get_records(bucket="monitor", collection="changes")
-    resource = await signed_resource(editor_client)
+    records = anonymous_client.get_records(bucket="monitor", collection="changes")
+    resource = signed_resource(editor_client)
 
     initial_preview = find_changes_record(
         records=records,
@@ -49,12 +49,12 @@ async def test_changes_plugin(
     )
 
     # 2. Upload records and request review
-    await upload_records(editor_client, 1)
-    await editor_client.patch_collection(data={"status": "to-review"})
+    upload_records(editor_client, 1)
+    editor_client.patch_collection(data={"status": "to-review"})
 
     # 3. Compare timestamps and assert that preview timestamp was bumped,
     #    and destination wasn't
-    records = await anonymous_client.get_records(bucket="monitor", collection="changes")
+    records = anonymous_client.get_records(bucket="monitor", collection="changes")
     preview = find_changes_record(
         records=records,
         bucket=resource["preview"]["bucket"],
@@ -70,8 +70,8 @@ async def test_changes_plugin(
     assert destination["last_modified"] == initial_destination["last_modified"]
 
     # 4. We approve the changes, and then assert that destination timestamp was bumped
-    await reviewer_client.patch_collection(data={"status": "to-sign"})
-    records = await anonymous_client.get_records(bucket="monitor", collection="changes")
+    reviewer_client.patch_collection(data={"status": "to-sign"})
+    records = anonymous_client.get_records(bucket="monitor", collection="changes")
     preview = find_changes_record(
         records=records,
         bucket=resource["preview"]["bucket"],

--- a/tests/integration/plugins/test_email.py
+++ b/tests/integration/plugins/test_email.py
@@ -24,9 +24,9 @@ async def test_email_plugin(
 
     if not skip_server_setup:
         setup_client = make_client(setup_auth)
-        await setup_server(setup_client, editor_client)
+        setup_server(setup_client, editor_client)
 
-        await setup_client.patch_bucket(
+        setup_client.patch_bucket(
             data={
                 "kinto-emailer": {
                     "hooks": [
@@ -44,16 +44,16 @@ async def test_email_plugin(
             },
         )
 
-    bucket_metadata = await editor_client.get_bucket()
+    bucket_metadata = editor_client.get_bucket()
     email_hooks = bucket_metadata["data"]["kinto-emailer"]["hooks"]
     assert [
         h for h in email_hooks if "ReviewRequested" in h["event"]
     ], "Email hook not found"
 
     # Create record, will set status to "work-in-progress"
-    await editor_client.create_record(data={"hola": "mundo"})
+    editor_client.create_record(data={"hola": "mundo"})
     # Request review!
-    await editor_client.patch_collection(data={"status": "to-review"})
+    editor_client.patch_collection(data={"status": "to-review"})
 
     email_files_created = set(os.listdir(mail_dir)) - existing_email_files
     assert email_files_created, "No emails created"

--- a/tests/integration/plugins/test_history.py
+++ b/tests/integration/plugins/test_history.py
@@ -18,23 +18,23 @@ async def test_history_plugin(
 
     if not skip_server_setup:
         setup_client = make_client(setup_auth)
-        await setup_server(setup_client, editor_client)
+        setup_server(setup_client, editor_client)
 
         if not keep_existing:
-            await setup_client.purge_history()
+            setup_client.purge_history()
 
     # Reset collection status.
-    collection = await editor_client.get_collection()
+    collection = editor_client.get_collection()
     timestamp_start = collection["data"]["last_modified"]
     if collection["data"]["status"] != "signed":
-        await editor_client.patch_collection(data={"status": "to-rollback"})
+        editor_client.patch_collection(data={"status": "to-rollback"})
 
     # Create record, will set status to "work-in-progress"
-    await editor_client.create_record(data={"hola": "mundo"})
+    editor_client.create_record(data={"hola": "mundo"})
     # Request review, will set status and update collection attributes.
-    await editor_client.patch_collection(data={"status": "to-review"})
+    editor_client.patch_collection(data={"status": "to-review"})
 
-    history_entries = await editor_client.get_history(
+    history_entries = editor_client.get_history(
         resource_name="collection",
         collection_id=editor_client.collection_name,
         _since=timestamp_start,

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -27,7 +27,7 @@ async def test_permissions_endpoint(
         setup_client = make_client(setup_auth)
         editor_client = make_client(editor_auth)
         reviewer_client = make_client(reviewer_auth)
-        await setup_server(setup_client, editor_client, reviewer_client)
+        setup_server(setup_client, editor_client, reviewer_client)
 
     for user in (editor_auth, reviewer_auth):
         resp = requests.get(

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,7 +1,7 @@
 import random
 from string import hexdigits
 
-from kinto_http import AsyncClient
+from kinto_http import Client
 from kinto_http.patch_type import JSONPatch
 
 
@@ -9,40 +9,40 @@ def _rand(size: int = 10) -> str:
     return "".join(random.choices(hexdigits, k=size))
 
 
-async def upload_records(client: AsyncClient, num: int):
+def upload_records(client: Client, num: int):
     records = []
     for _ in range(num):
         data = {"one": _rand(1000)}
-        record = await client.create_record(data=data)
+        record = client.create_record(data=data)
         records.append(record["data"])
     return records
 
 
-async def setup_server(
-    setup_client: AsyncClient,
-    editor_client: AsyncClient = None,
-    reviewer_client: AsyncClient = None,
+def setup_server(
+    setup_client: Client,
+    editor_client: Client = None,
+    reviewer_client: Client = None,
 ):
-    await setup_client.create_bucket(
+    setup_client.create_bucket(
         permissions={
             "collection:create": ["system.Authenticated"],
         },
         if_not_exists=True,
     )
-    await setup_client.create_collection(if_not_exists=True)
+    setup_client.create_collection(if_not_exists=True)
 
     if editor_client:
-        editor_id = (await editor_client.server_info())["user"]["id"]
+        editor_id = (editor_client.server_info())["user"]["id"]
         data = JSONPatch([{"op": "add", "path": "/data/members/0", "value": editor_id}])
-        await setup_client.patch_group(
+        setup_client.patch_group(
             id=f"{setup_client.collection_name}-editors", changes=data
         )
 
     if reviewer_client:
-        reviewer_id = (await reviewer_client.server_info())["user"]["id"]
+        reviewer_id = (reviewer_client.server_info())["user"]["id"]
         data = JSONPatch(
             [{"op": "add", "path": "/data/members/0", "value": reviewer_id}]
         )
-        await setup_client.patch_group(
+        setup_client.patch_group(
             id=f"{setup_client.collection_name}-reviewers", changes=data
         )

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,7 +18,7 @@ wait_for_server () {
   echo "Waiting for $SERVER to become available"
   wget -q --retry-connrefused --waitretry=1 -O /dev/null $SERVER || (echo "Can't reach $SERVER" && exit 1)
   echo "verifying $SERVER heartbeat"
-  http --check-status --body --json --pretty format GET ${SERVER}__heartbeat__ ; echo
+  http --check-status --body --json --pretty format GET $SERVER/__heartbeat__ ; echo
 }
 
 case $1 in

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -30,7 +30,7 @@ integration-test)
 browser-test)
     shift
     wait_for_server
-    pytest browser_test.py --log-level=DEBUG
+    pytest browser_test.py --log-level=DEBUG --browser firefox
     ;;
 *)
     exec "$@"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -30,8 +30,7 @@ integration-test)
 browser-test)
     shift
     wait_for_server
-    # pytest --base-url $SERVER --verify-base-url browser_test.py --server $SERVER --log-level=DEBUG
-    py.test browser_test.py --log-level=DEBUG
+    pytest browser_test.py --log-level=DEBUG
     ;;
 *)
     exec "$@"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,7 +18,7 @@ wait_for_server () {
   echo "Waiting for $SERVER to become available"
   wget -q --retry-connrefused --waitretry=1 -O /dev/null $SERVER || (echo "Can't reach $SERVER" && exit 1)
   echo "verifying $SERVER heartbeat"
-  http --check-status --body --json --pretty format GET $SERVER/__heartbeat__ ; echo
+  http --check-status --body --json --pretty format GET ${SERVER}__heartbeat__ ; echo
 }
 
 case $1 in
@@ -30,8 +30,8 @@ integration-test)
 browser-test)
     shift
     wait_for_server
-    wget -q --tries=180 --retry-connrefused --waitretry=1 -O /dev/null http://selenium:4444/wd/hub/status || (echo "Can't reach Selenium" && exit 1)
-    pytest --driver Remote --capability browserName firefox --base-url $SERVER/admin/ --verify-base-url browser_test.py --server $SERVER
+    # pytest --base-url $SERVER --verify-base-url browser_test.py --server $SERVER --log-level=DEBUG
+    py.test browser_test.py --log-level=DEBUG
     ;;
 *)
     exec "$@"


### PR DESCRIPTION
Fixes #522 by replacing selenium with playwright. These tests are simple and are meant as a general check that the kinto-admin UI exists, is accessible, and we can at least submit a review request. Detailed testing will be built out in the kinto-admin project.

Making these changes in `remote-settings` was a bit more complicated than `kinto`. Let me know if we'd like to see anything done differently.