### PR TITLE
Include Dependabot pull-requests in changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,7 +1,4 @@
 changelog:
-  exclude:
-    authors:
-      - dependabot
   categories:
     - title: Breaking Changes
       labels:


### PR DESCRIPTION
Otherwise upgrades of Python versions or upgrades of key libraries are not mentionned in changelog, which is unfortunate