### PR TITLE
Sign commit generated by github action for kinto-admin update

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -65,11 +65,26 @@ jobs:
             echo "pr_needed=false" >> $GITHUB_OUTPUT
           else
             git checkout -b "$BRANCH_NAME"
-            echo "$LATEST_RELEASE" > kinto-admin/VERSION        
-            git commit -am "Update Kinto Admin to $LATEST_RELEASE"
             git push origin $BRANCH_NAME
             echo "pr_needed=true" >> $GITHUB_OUTPUT
           fi
+      
+      - name: Commit change
+        if: ${{ steps.compare_versions.outputs.update_needed == 'true' && steps.create_branch.outputs.pr_needed == 'true'}}
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: updates/kinto-admin-${{ steps.latest_release_version.outputs.version }}
+          LATEST_RELEASE: ${{ steps.latest_release_version.outputs.version }}
+        run: |
+          echo "$LATEST_RELEASE" > kinto-admin/VERSION
+          SHA=$(git rev-parse $BRANCH_NAME:kinto-admin/VERSION)
+          CONTENT=$(base64 -i kinto-admin/VERSION)
+          gh api --method PUT /repos/:owner/:repo/contents/kinto-admin/VERSION \
+            --field message="Update Kinto Admin to $LATEST_RELEASE"
+            --field content="$CONTENT" 
+            --field encoding="base64" 
+            --field branch="$BRANCH_NAME" 
+            --field sha="$SHA"
 
       - name: Create pull request
         if: ${{ steps.compare_versions.outputs.update_needed == 'true' && steps.create_branch.outputs.pr_needed == 'true'}}


### PR DESCRIPTION
Adjusting our github action workflow that updates kinto-admin. Making the request over the github API should result in a signed commit.