### PR TITLE
Standardizing browser tests between environments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,7 @@ Because the tests are capable of running against environments with existing data
  - All tests have access to the same bucket, collection, and users
  - Tests are not allowed to delete the bucket(s), collection(s) or users
  - Test collection records are purged before each test
+ - Test collection is expected to have one property named "title" and a required file attachment
 
 
 

--- a/kinto-remote-settings/tests/signer/test_events.py
+++ b/kinto-remote-settings/tests/signer/test_events.py
@@ -33,9 +33,9 @@ class ResourceEventsTest(BaseWebTest, unittest.TestCase):
         settings["signer.ecdsa.private_key"] = os.path.join(here, "ecdsa.private.pem")
 
         settings["event_listeners"] = "ks"
-        settings[
-            "event_listeners.ks.use"
-        ] = "kinto_remote_settings.testing.mock_listener"
+        settings["event_listeners.ks.use"] = (
+            "kinto_remote_settings.testing.mock_listener"
+        )
         return settings
 
     def setUp(self):

--- a/kinto-remote-settings/tests/signer/test_signoff_flow.py
+++ b/kinto-remote-settings/tests/signer/test_signoff_flow.py
@@ -1594,9 +1594,9 @@ class BatchCreationTest(PostgresWebTest, unittest.TestCase):
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
 
-        settings[
-            "kinto.signer.resources"
-        ] = "/buckets/main-workspace -> /buckets/main-preview -> /buckets/main"
+        settings["kinto.signer.resources"] = (
+            "/buckets/main-workspace -> /buckets/main-preview -> /buckets/main"
+        )
 
         return settings
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,7 +200,55 @@ def _setup_server(
         if_not_exists=True,
     )
 
-    setup_client.create_collection(if_not_exists=True)
+    setup_client.create_collection(
+        if_not_exists=True,
+        data={
+            "attachment": {"enabled": True, "required": True},
+            "cache_expires": 0,
+            "displayFields": ["title", "attachment.filename"],
+            "id": "integration-tests",
+            "schema": {
+                "description": "Integration test data",
+                "properties": {
+                    "attachment": {
+                        "additionalProperties": False,
+                        "description": "Information about the attached file.",
+                        "properties": {
+                            "filename": {"title": "Filename", "type": "string"},
+                            "hash": {"title": "Hash", "type": "string"},
+                            "location": {"title": "URL", "type": "string"},
+                            "mimetype": {"title": "MIME type", "type": "string"},
+                            "original": {
+                                "additionalProperties": False,
+                                "properties": {
+                                    "filename": {"title": "Filename", "type": "string"},
+                                    "hash": {"title": "Hash", "type": "string"},
+                                    "mimetype": {
+                                        "title": "MIME type",
+                                        "type": "string",
+                                    },
+                                    "size": {"title": "Size (bytes)", "type": "number"},
+                                },
+                                "title": "Pre-gzipped file",
+                                "type": "object",
+                            },
+                            "size": {"title": "Size (bytes)", "type": "number"},
+                        },
+                        "title": "The attachment itself",
+                        "type": "object",
+                    },
+                    "title": {
+                        "description": "Some text title",
+                        "title": "Title",
+                        "type": "string",
+                    },
+                },
+                "type": "object",
+            },
+            "sort": "-last_modified",
+            "uiSchema": {},
+        },
+    )
 
     editor_id = (editor_client.server_info())["user"]["id"]
     data = JSONPatch([{"op": "add", "path": "/data/members/0", "value": editor_id}])

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -38,7 +38,8 @@ def test_login_and_submit_review(
 
     # create a record
     page.get_by_text("Create record").first.click()
-    page.get_by_label("JSON record").fill('{"prop": "val"}')
+    page.get_by_label("Title").fill("val")
+    page.get_by_label("File attachment*").set_input_files("kinto-logo.svg")
     page.get_by_text("Create record").click()
 
     # request a review
@@ -66,7 +67,7 @@ def test_review_requested_changes(
     editor_auth,
 ):
     # setup changes to review
-    editor_client.create_record(data={"prop": "val"})
+    editor_client.create_record(data={"title": "val"})
     editor_client.patch_collection(data={"status": "to-review"})
 
     # load login page


### PR DESCRIPTION
This PR standardizes the collection config across tested environments. This should allow us to have more confidence in automated releases, which will be the next step for us.

Also ran `make format` which touched a couple unexpected files.

I ran the test container produced by this against dev as an additional check.