### PR TITLE
Switching admin-pull to use alpine:3 image

### DIFF
--- a/RemoteSettings.Dockerfile
+++ b/RemoteSettings.Dockerfile
@@ -29,7 +29,7 @@ RUN pip install ./kinto-remote-settings
 
 # We build the Kinto Admin assets at the specific
 # version specified in `kinto-admin/VERSION`.
-FROM node:21.6.2 as build-admin
+FROM debian:latest as get-admin
 WORKDIR /opt
 COPY bin/pull-kinto-admin.sh .
 COPY kinto-admin/ kinto-admin/
@@ -61,7 +61,7 @@ RUN chown 10001:10001 /app && \
 COPY --chown=app:app . .
 COPY --from=compile /opt/dogstatsd_plugin.so .
 
-COPY --from=build-admin /opt/kinto-admin/build $KINTO_ADMIN_ASSETS_PATH
+COPY --from=get-admin /opt/kinto-admin/build $KINTO_ADMIN_ASSETS_PATH
 
 # Generate local key pair to simplify running without Autograph out of the box (see `config/testing.ini`)
 RUN python -m kinto_remote_settings.signer.generate_keypair /app/ecdsa.private.pem /app/ecdsa.public.pem

--- a/RemoteSettings.Dockerfile
+++ b/RemoteSettings.Dockerfile
@@ -30,6 +30,7 @@ RUN pip install ./kinto-remote-settings
 # We build the Kinto Admin assets at the specific
 # version specified in `kinto-admin/VERSION`.
 FROM debian:latest as get-admin
+RUN apt update && apt install -y wget
 WORKDIR /opt
 COPY bin/pull-kinto-admin.sh .
 COPY kinto-admin/ kinto-admin/

--- a/RemoteSettings.Dockerfile
+++ b/RemoteSettings.Dockerfile
@@ -27,10 +27,8 @@ COPY ./kinto-remote-settings ./kinto-remote-settings
 COPY version.json .
 RUN pip install ./kinto-remote-settings
 
-# We build the Kinto Admin assets at the specific
-# version specified in `kinto-admin/VERSION`.
-FROM debian:latest as get-admin
-RUN apt update && apt install -y wget
+# We pull the Kinto Admin assets at the version specified in `kinto-admin/VERSION`.
+FROM alpine:3 as get-admin
 WORKDIR /opt
 COPY bin/pull-kinto-admin.sh .
 COPY kinto-admin/ kinto-admin/

--- a/bin/pull-kinto-admin.sh
+++ b/bin/pull-kinto-admin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -euo pipefail
 
 VERSION=$(cat `pwd`/kinto-admin/VERSION)
@@ -8,5 +8,3 @@ TAG="v${VERSION}"
 wget https://github.com/Kinto/kinto-admin/releases/download/${TAG}/kinto-admin-release.tar
 rm -rf ./kinto-admin/build && mkdir ./kinto-admin/build
 tar -xf kinto-admin-release.tar -C ./kinto-admin/build && rm kinto-admin-release.tar
-# copy the VERSION file if not present (kinto-admin <= v3.0.3)
-cp -n `pwd`/kinto-admin/VERSION ./kinto-admin/build/

--- a/bin/pull-kinto-admin.sh
+++ b/bin/pull-kinto-admin.sh
@@ -5,7 +5,7 @@ VERSION=$(cat `pwd`/kinto-admin/VERSION)
 TAG="v${VERSION}"
 
 # download and unzip release
-curl -OL https://github.com/Kinto/kinto-admin/releases/download/${TAG}/kinto-admin-release.tar
+wget https://github.com/Kinto/kinto-admin/releases/download/${TAG}/kinto-admin-release.tar
 rm -rf ./kinto-admin/build && mkdir ./kinto-admin/build
 tar -xf kinto-admin-release.tar -C ./kinto-admin/build && rm kinto-admin-release.tar
 # copy the VERSION file if not present (kinto-admin <= v3.0.3)


### PR DESCRIPTION
Changing the docker image used to pull the admin files. Mainly doing this so dependabot stops [creating PR's](https://github.com/mozilla/remote-settings/pull/573) for it.

Also switched to wget while here. We will now error on 404's rather than following them to the pretty error page and failing when extracting the tar.