### PR TITLE
Specify keyid for Autograph signing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -196,7 +196,7 @@
         "filename": "kinto-remote-settings/README.rst",
         "hashed_secret": "3650b7f537d2e64041a1e2ae269361c7480737ab",
         "is_verified": false,
-        "line_number": 392
+        "line_number": 395
       }
     ],
     "kinto-remote-settings/tests/changes/config.ini": [
@@ -275,5 +275,5 @@
       }
     ]
   },
-  "generated_at": "2023-10-18T14:40:13Z"
+  "generated_at": "2024-03-15T16:02:37Z"
 }

--- a/kinto-remote-settings/README.rst
+++ b/kinto-remote-settings/README.rst
@@ -235,6 +235,8 @@ To do so, use the following settings:
 +------------------------------------+--------------------------------------------------------------------------+
 | kinto.signer.autograph.hawk_secret | The hawk secret used to issue the requests.                              |
 +------------------------------------+--------------------------------------------------------------------------+
+| kinto.signer.autograph.key_id      | The Autograph key ID (default: "remote-settings")                        |
++------------------------------------+--------------------------------------------------------------------------+
 
 
 Workflows
@@ -308,6 +310,7 @@ Settings can be prefixed with bucket id:
 
     kinto.signer.<bucket-id>.autograph.hawk_id = bob
     kinto.signer.<bucket-id>.autograph.hawk_secret = a-secret
+    kinto.signer.<bucket-id>.autograph.key_id = cas_cur_remote-settings
 
 
 Or prefixed with bucket and collection:

--- a/kinto-remote-settings/tests/signer/test_signer.py
+++ b/kinto-remote-settings/tests/signer/test_signer.py
@@ -133,6 +133,7 @@ class AutographSignerTest(unittest.TestCase):
             hawk_id="alice",
             hawk_secret="fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
             server_url="http://localhost:8000",
+            keyid="remote-settings",
         )
 
     @mock.patch("kinto_remote_settings.signer.backends.autograph.requests")
@@ -169,4 +170,5 @@ class AutographSignerTest(unittest.TestCase):
             server_url=mock.sentinel.server_url,
             hawk_id=mock.sentinel.hawk_id,
             hawk_secret=mock.sentinel.hawk_secret,
+            keyid="remote-settings",
         )

--- a/kinto-remote-settings/tests/signer/test_signer.py
+++ b/kinto-remote-settings/tests/signer/test_signer.py
@@ -144,7 +144,12 @@ class AutographSignerTest(unittest.TestCase):
         requests.post.assert_called_with(
             "http://localhost:8000/sign/data",
             auth=self.signer.auth,
-            json=[{"input": "dGVzdCBkYXRh"}],
+            json=[
+                {
+                    "input": "dGVzdCBkYXRh",
+                    "keyid": "remote-settings",
+                }
+            ],
         )
         assert signature_bundle["signature"] == SIGNATURE
 


### PR DESCRIPTION
By default Autograph picks the first key in its config.

In order to support an ongoing certificate rotation, we were asked to specify the `keyid` explicitly in the signing payload. See https://github.com/mozilla-services/autograph/blob/main/docs/endpoints.md#signdata