### PR TITLE
Always copy 'schema' and 'attachment' attributes to preview and final collections

### DIFF
--- a/kinto-remote-settings/src/kinto_remote_settings/signer/updater.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/signer/updater.py
@@ -381,7 +381,7 @@ class LocalUpdater(object):
         new_collection["signature"] = signature
         for attr in PUBLISHED_COLLECTION_FIELDS:
             if attr in source_attributes:
-                new_collection.setdefault(attr, source_attributes[attr])
+                new_collection[attr] = source_attributes[attr]
 
         updated = self.storage.update(
             parent_id=parent_id,

--- a/kinto-remote-settings/tests/signer/test_updater.py
+++ b/kinto-remote-settings/tests/signer/test_updater.py
@@ -161,7 +161,7 @@ class LocalUpdaterTest(unittest.TestCase):
             obj={
                 "id": 1234,
                 "signature": mock.sentinel.signature,
-                "sort": "-age",
+                "sort": "size",
                 "displayFields": ["name"],
             },
         )


### PR DESCRIPTION
Change the original code contributed here: https://github.com/Kinto/kinto-signer/pull/163

I don't remember why (8 years ago) we had this condition for fields: `(if not set)`


Without the change of this PR, we can observe that the destination attributes are never updated.
Example:
https://firefox.settings.services.mozilla.com/v1/buckets/main-preview/collections/search-telemetry-v2
Does not contain https://github.com/mozilla-services/remote-settings-permissions/commit/a22956c3931cec03b130770708288e340128d9a3

This is required for our work on bundles https://github.com/mozilla-services/remote-settings-lambdas/pull/1474 so that the `attachment.bundle: true` flag is copied to preview and main collections. 
