### PR TITLE
Add 'bucket' field to changeset metadata

### DIFF
--- a/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
@@ -376,7 +376,10 @@ def get_changeset(request):
     request.response.last_modified = last_modified / 1000.0
 
     data = {
-        "metadata": metadata,
+        "metadata": {
+            **metadata,
+            "bucket": bid,
+        },
         "timestamp": records_timestamp,
         "changes": changes,
     }

--- a/kinto-remote-settings/tests/changes/test_changeset.py
+++ b/kinto-remote-settings/tests/changes/test_changeset.py
@@ -39,6 +39,7 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
         assert "metadata" in data
         assert "timestamp" in data
         assert "changes" in data
+        assert data["metadata"]["bucket"] == "blocklists"
         assert data["metadata"]["id"] == "certificates"
         assert len(data["changes"]) == 1
         assert data["changes"][0]["dev-edition"] is True


### PR DESCRIPTION
Context: #631 
 
This will allow the client code to get the bucket from the extracted data instead of parsing the json filename (`{bid}--{cid}`).

It will allow us to simplify this line from the build bundle job:

https://github.com/mozilla-services/remote-settings-lambdas/blob/48a4e4a2476de4ef2e16308a43a4e15c7ec51ff8/commands/build_bundles.py#L53

and just do `return all_changesets`