### PR TITLE
Copy 'flags' collection metadata field to published collections

### DIFF
--- a/kinto-remote-settings/src/kinto_remote_settings/signer/updater.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/signer/updater.py
@@ -16,7 +16,14 @@ logger = logging.getLogger(__name__)
 FIELD_ID = "id"
 FIELD_LAST_MODIFIED = "last_modified"
 # Source collection fields to be copied to destination.
-PUBLISHED_COLLECTION_FIELDS = ("schema", "sort", "displayFields", "attachment")
+PUBLISHED_COLLECTION_FIELDS = (
+    "flags",  # used in build_bundles lambda.
+    # Admin UI fields
+    "attachment",  # also used in build_bundles lambda.
+    "schema",
+    "sort",
+    "displayFields",
+)
 
 
 class TRACKING_FIELDS(Enum):

--- a/kinto-remote-settings/tests/signer/test_updater.py
+++ b/kinto-remote-settings/tests/signer/test_updater.py
@@ -166,6 +166,28 @@ class LocalUpdaterTest(unittest.TestCase):
             },
         )
 
+    def test_set_destination_signature_copies_flags_field(self):
+        self.storage.get.return_value = {
+            "id": 1234,
+            "last_modified": 1234,
+        }
+        self.updater.set_destination_signature(
+            mock.sentinel.signature,
+            {"flags": ["startup"]},
+            DummyRequest(),
+        )
+
+        self.storage.update.assert_called_with(
+            resource_name="collection",
+            object_id="destcollection",
+            parent_id="/buckets/destbucket",
+            obj={
+                "id": 1234,
+                "signature": mock.sentinel.signature,
+                "flags": ["startup"],
+            },
+        )
+
     def test_update_source_status_modifies_the_source_collection(self):
         self.storage.get.return_value = {
             "id": 1234,


### PR DESCRIPTION
Context: https://github.com/mozilla-services/remote-settings-lambdas/pull/1481
and https://bugzilla.mozilla.org/show_bug.cgi?id=1907327#c2

