### PR TITLE
Fix docker warnings

### DIFF
--- a/RemoteSettings.Dockerfile
+++ b/RemoteSettings.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.5 as compile
+FROM python:3.12.5 AS compile
 
 ENV PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
@@ -28,14 +28,14 @@ COPY version.json .
 RUN pip install ./kinto-remote-settings
 
 # We pull the Kinto Admin assets at the version specified in `kinto-admin/VERSION`.
-FROM alpine:3 as get-admin
+FROM alpine:3 AS get-admin
 WORKDIR /opt
 COPY bin/pull-kinto-admin.sh .
 COPY kinto-admin/ kinto-admin/
 RUN ./pull-kinto-admin.sh
 
 
-FROM python:3.12.5-slim as production
+FROM python:3.12.5-slim AS production
 
 ENV KINTO_INI=config/local.ini \
     KINTO_ADMIN_ASSETS_PATH=/app/kinto-admin/build/ \
@@ -71,6 +71,6 @@ ENTRYPOINT ["./bin/run.sh"]
 # Run uwsgi by default
 CMD ["start"]
 
-FROM production as local
+FROM production AS local
 # create directories for volume mounts used in browser tests / local development
 RUN mkdir -p -m 777 /app/mail && mkdir -p -m 777 /tmp/attachments

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 volumes:
   db-data:
   debug-mail:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,11 @@ services:
       retries: 30
 
   memcached:
+    platform: linux/amd64
     image: memcached:1
 
   autograph:
+    platform: linux/amd64
     image: mozilla/autograph
     user: root
     volumes:


### PR DESCRIPTION
```
WARN[0000] /Users/mathieu/Code/Mozilla/remote-settings/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
[+] Building 2.8s (32/32) FINISHED                                      docker:desktop-linux
 => [web internal] load build definition from RemoteSettings.Dockerfile                 0.0s
 => => transferring dockerfile: 2.51kB                                                  0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)          0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 31)         0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 38)         0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 74)
```