### PR TITLE
 Fix #655: propagate fields of collection metadata on signature refresh

### DIFF
--- a/kinto-remote-settings/src/kinto_remote_settings/signer/updater.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/signer/updater.py
@@ -142,11 +142,19 @@ class LocalUpdater(object):
 
     def refresh_signature(self, request, next_source_status=None):
         """Refresh the signature without moving records."""
+        source_attributes = self.storage.get(
+            parent_id="/buckets/%s" % self.source["bucket"],
+            resource_name="collection",
+            object_id=self.source["collection"],
+        )
+
         records, timestamp = self.get_destination_records(empty_none=False)
         serialized_records = canonical_json(records, timestamp)
         logger.debug(f"{self.source_collection_uri}:\t'{serialized_records}'")
         signature = self.signer.sign(serialized_records)
-        self.set_destination_signature(signature, request=request, source_attributes={})
+        self.set_destination_signature(
+            signature, request=request, source_attributes=source_attributes
+        )
 
         if next_source_status is not None:
             current_userid = request.prefixed_userid

--- a/kinto-remote-settings/tests/signer/test_updater.py
+++ b/kinto-remote-settings/tests/signer/test_updater.py
@@ -285,3 +285,37 @@ class LocalUpdaterTest(unittest.TestCase):
             object_id="sourcecollection",
             obj=new_attrs,
         )
+
+    def test_refresh_signature_copies_published_attributes_too(self):
+        self.storage.list_all.return_value = []
+        self.storage.get.side_effect = (
+            # while getting source_attributes
+            {
+                "id": "sourcecollection",
+                "attachment": {"bundle": True},
+                "field": "ignored",
+            },
+            # while getting dest attributes
+            {
+                "id": "destcollection",
+            },
+            # while updating source attributes
+            {
+                "id": "sourcecollection",
+            },
+        )
+        self.updater.signer.sign.return_value = {}
+
+        self.updater.refresh_signature(DummyRequest(), "work-in-progress")
+
+        breakpoint()
+        self.storage.update.assert_any_call(
+            resource_name="collection",
+            parent_id="/buckets/destbucket",
+            object_id="destcollection",
+            obj={
+                "id": "destcollection",
+                "attachment": {"bundle": True},
+                "signature": {},
+            },
+        )

--- a/kinto-remote-settings/tests/signer/test_updater.py
+++ b/kinto-remote-settings/tests/signer/test_updater.py
@@ -308,7 +308,6 @@ class LocalUpdaterTest(unittest.TestCase):
 
         self.updater.refresh_signature(DummyRequest(), "work-in-progress")
 
-        breakpoint()
         self.storage.update.assert_any_call(
             resource_name="collection",
             parent_id="/buckets/destbucket",


### PR DESCRIPTION
Fix #655
