### PR TITLE
Rename matchdict fields to be aligned with other Kinto resources

### DIFF
--- a/kinto-remote-settings/src/kinto_remote_settings/changes/__init__.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/changes/__init__.py
@@ -10,7 +10,7 @@ CHANGES_COLLECTION_PATH = "{}/collections/{}".format(
     MONITOR_BUCKET_PATH, CHANGES_COLLECTION
 )
 CHANGES_RECORDS_PATH = "{}/records".format(CHANGES_COLLECTION_PATH)
-CHANGESET_PATH = "/buckets/{bid}/collections/{cid}/changeset"
+CHANGESET_PATH = "/buckets/{bucket_id}/collections/{collection_id}/changeset"
 
 
 def includeme(config):

--- a/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
@@ -228,8 +228,8 @@ class ChangeSetRoute(RouteFactory):
 
     def __init__(self, request):
         super().__init__(request)
-        bid = request.matchdict["bid"]
-        cid = request.matchdict["cid"]
+        bid = request.matchdict["bucket_id"]
+        cid = request.matchdict["collection_id"]
         collection_uri = instance_uri(request, "collection", bucket_id=bid, id=cid)
         # This route context will be the same as when reaching the collection URI.
         self.permission_object_id = collection_uri
@@ -279,8 +279,8 @@ class ChangeSetSchema(colander.MappingSchema):
     schema=ChangeSetSchema(), permission="read", validators=(colander_validator,)
 )
 def get_changeset(request):
-    bid = request.matchdict["bid"]
-    cid = request.matchdict["cid"]
+    bid = request.matchdict["bucket_id"]
+    cid = request.matchdict["collection_id"]
 
     storage = request.registry.storage
 


### PR DESCRIPTION
I plan on using `matchdict` fields as metrics labels.

In order to match other resources in Kinto (like records endpoints etc.), it's better if bucket and collection fields have the same name.