### PR TITLE
Allow any file extension for attachments

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -132,14 +132,14 @@
         "filename": "config/local.ini",
         "hashed_secret": "215c95f7ecd7d592f10a7f540c30c4b8abeeadb9",
         "is_verified": false,
-        "line_number": 112
+        "line_number": 113
       },
       {
         "type": "Secret Keyword",
         "filename": "config/local.ini",
         "hashed_secret": "215c95f7ecd7d592f10a7f540c30c4b8abeeadb9",
         "is_verified": false,
-        "line_number": 112
+        "line_number": 113
       }
     ],
     "docs/tutorial-dev-kinto-admin.rst": [
@@ -275,5 +275,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-24T13:27:39Z"
+  "generated_at": "2024-11-06T17:06:01Z"
 }

--- a/config/local.ini
+++ b/config/local.ini
@@ -64,6 +64,7 @@ kinto.attachment.base_url =
 # See uwsgi static-map setting
 kinto.attachment.extra.base_url = http://localhost:8888/attachments
 kinto.attachment.folder = {bucket_id}/{collection_id}
+kinto.attachment.extensions = any
 
 
 #


### PR DESCRIPTION
This is needed to be able to submit attachments for AMO (addons-bloomfilters). Apparently, this is the config on prod too.