### PR TITLE
Adjusting scheduled workflow to mark the PR's it creates for auto-mere with squash

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -93,9 +93,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: updates/kinto-admin-${{ steps.latest_release_version.outputs.version }}
         run: |
-          gh pr create \
+          PR_REF=$(gh pr create \
             --title "Update Kinto Admin version to ${{ steps.latest_release_version.outputs.version }}" \
             --body "Updating kinto-admin to latest release" \
             --base "main" \
             --head "$BRANCH_NAME" \
-            --label "dependencies"
+            --label "dependencies")
+          gh pr merge --auto --squash $PR_REF


### PR DESCRIPTION
Our scheduled job that updates the kinto-admin UI automatically does not auto-merge after we approve.
We're used to this happening so we sometimes miss that the PR is still open for a bit.
This sets the PR to auto-merge once all requirements are met, with `--squash` to squash commits.

Note: I tested these commands manually with a sandbox repo. But as with all actions changes, I'm 50/50 on this working right the first time.