### PR TITLE
Sort entries by `-last_modified` in monitor/changes changeset endpoint

### DIFF
--- a/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
@@ -311,8 +311,13 @@ def get_changeset(request):
         last_modified = (
             records_timestamp  # The collection 'monitor/changes' is virtual.
         )
+        # Mimic records endpoint and sort by timestamp desc.
+        sorting = [Sort("last_modified", -1)]
         changes = model.get_objects(
-            filters=filters, limit=limit, include_deleted=include_deleted
+            filters=filters,
+            limit=limit,
+            include_deleted=include_deleted,
+            sorting=sorting,
         )
 
     else:

--- a/kinto-remote-settings/tests/changes/test_changeset.py
+++ b/kinto-remote-settings/tests/changes/test_changeset.py
@@ -231,3 +231,22 @@ class MonitorChangesetViewTest(BaseWebTest, unittest.TestCase):
             headers=self.headers,
         )
         assert len(resp.json["changes"]) == 1
+
+    def test_entries_are_sorted_by_timestamp_desc(self):
+        resp = self.app.get(
+            self.changeset_uri,
+            headers=self.headers,
+        )
+        data = resp.json
+        assert data["changes"][0]["collection"] == "certificates"
+
+        self.app.post_json(
+            self.records_uri.format(cid="cfr"), SAMPLE_RECORD, headers=self.headers
+        )
+
+        resp = self.app.get(
+            self.changeset_uri,
+            headers=self.headers,
+        )
+        data = resp.json
+        assert data["changes"][0]["collection"] == "cfr"


### PR DESCRIPTION
Mimic behaviour of `monitor/changes` records endpoint

The list of collections in the DevTools will now be sorted by `-last_modified` since the order of the list comes from the `RemoteSettings.inspect()` function ([source](https://searchfox.org/mozilla-central/rev/f53c09a22edc700ab1a9eaaf4da0f0dd9f11bff3/services/settings/remote-settings.sys.mjs#604-638))