### PR TITLE
Fixes #740: Expand patterns in settings

### DIFF
--- a/config/local.ini
+++ b/config/local.ini
@@ -114,6 +114,9 @@ kinto.signer.autograph.server_url = http://autograph:8000
 kinto.signer.autograph.hawk_id = kintodev
 kinto.signer.autograph.hawk_secret = 3isey64n25fim18chqgewirm6z2gwva1mas0eu71e9jtisdwv6bd
 
+# quicksuggest collections don't new review
+kinto.signer.staging.quicksuggest-(\w+)-(desktop|mobile).to_review_enabled = false
+
 # blocklists/addons-bloomfilters doesn't need review (bug 1623984).
 kinto.signer.staging.addons-bloomfilters.to_review_enabled = false
 

--- a/config/local.ini
+++ b/config/local.ini
@@ -114,9 +114,6 @@ kinto.signer.autograph.server_url = http://autograph:8000
 kinto.signer.autograph.hawk_id = kintodev
 kinto.signer.autograph.hawk_secret = 3isey64n25fim18chqgewirm6z2gwva1mas0eu71e9jtisdwv6bd
 
-# quicksuggest collections don't new review
-kinto.signer.staging.quicksuggest-(\w+)-(desktop|mobile).to_review_enabled = false
-
 # blocklists/addons-bloomfilters doesn't need review (bug 1623984).
 kinto.signer.staging.addons-bloomfilters.to_review_enabled = false
 
@@ -126,6 +123,9 @@ kinto.signer.main-workspace.nimbus-web-preview.to_review_enabled = false
 
 # crash-reports-ondemand has multi-signoff disabled. See RRA ticket (SA-137)
 kinto.signer.main-workspace.crash-reports-ondemand.to_review_enabled = false
+
+# quicksuggest collections don't new review
+kinto.signer.main-workspace.quicksuggest-(\w+)-(desktop|mobile).to_review_enabled = false
 
 #
 # Simple daemon (see `run.sh start`)


### PR DESCRIPTION
fixes #740


With this approach, we turn glob settings into real settings:
- expanded settings show up in root URL capabilities output
- no modification of existing code around permission verification
- only read list of collections in DB on startup and when a new collection is created

Current limitations:
- cannot use `.` in regexps to match collections names (eg `([a-zA-Z0-9_-]*)` instead of `(.*)`)
- have to use `(` `)` to enable expansions

I believe it is good enough to get started with our use case (see issue description)
