### PR TITLE
Clean up useless `group_check_enabled` setting from demo config

### DIFF
--- a/config/local.ini
+++ b/config/local.ini
@@ -116,17 +116,13 @@ kinto.signer.autograph.hawk_secret = 3isey64n25fim18chqgewirm6z2gwva1mas0eu71e9j
 
 # blocklists/addons-bloomfilters doesn't need review (bug 1623984).
 kinto.signer.staging.addons-bloomfilters.to_review_enabled = false
-kinto.signer.staging.addons-bloomfilters.group_check_enabled = false
 
 # Nimbus QA/preview collection has multi-signoff disabled. See Bug 1693394 and Bug 1911371
 kinto.signer.main-workspace.nimbus-preview.to_review_enabled = false
-kinto.signer.main-workspace.nimbus-preview.group_check_enabled = false
 kinto.signer.main-workspace.nimbus-web-preview.to_review_enabled = false
-kinto.signer.main-workspace.nimbus-web-preview.group_check_enabled = false
 
 # crash-reports-ondemand has multi-signoff disabled. See RRA ticket (SA-137)
 kinto.signer.main-workspace.crash-reports-ondemand.to_review_enabled = false
-kinto.signer.main-workspace.crash-reports-ondemand.group_check_enabled = false
 
 #
 # Simple daemon (see `run.sh start`)


### PR DESCRIPTION
Since v27 this setting is not read anymore
https://github.com/mozilla/remote-settings/blob/2e6d1d2ec663481d7098f7575ea6bf8e0dabdc0d/CHANGELOG.rst#2700-2021-12-10