### PR TITLE
Publish ARM64 Docker image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,7 +48,10 @@ jobs:
           target: production
           push: true
           tags: ${{ steps.docker-metadata.outputs.tags }}
-  
+          platforms:
+            - linux/amd64
+            - linux/arm64
+
   browser_test_container:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Follow-up from https://github.com/Kinto/kinto/pull/3490