### PR TITLE
Enable buildx to enable multiplatform builds

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Enable multiplatform builds
         uses: docker/setup-buildx-action@v3
         with:
@@ -64,6 +66,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Enable multiplatform builds
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Enable multiplatform builds
+        uses: docker/setup-buildx-action@v3
       - name: Set tag version
         run: echo "LATEST_TAG=$(git describe --tags --abbrev=4)" >> "$GITHUB_ENV"
       - name: Create version.json
@@ -57,6 +59,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Enable multiplatform builds
+        uses: docker/setup-buildx-action@v3
       - name: Set tag version
         run: echo "LATEST_TAG=$(git describe --tags --abbrev=4)" >> "$GITHUB_ENV"
       - name: Docker metadata

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - "*"
 
+env:
+  BUILDX_NO_DEFAULT_ATTESTATIONS: 1 # Reduce warnings from Docker Buildx
+
 jobs:
   server_container:
     runs-on: ubuntu-latest
@@ -17,6 +20,8 @@ jobs:
           fetch-depth: 0
       - name: Enable multiplatform builds
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: "--debug" # Enable detailed logging
       - name: Set tag version
         run: echo "LATEST_TAG=$(git describe --tags --abbrev=4)" >> "$GITHUB_ENV"
       - name: Create version.json
@@ -61,6 +66,8 @@ jobs:
           fetch-depth: 0
       - name: Enable multiplatform builds
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: "--debug" # Enable detailed logging
       - name: Set tag version
         run: echo "LATEST_TAG=$(git describe --tags --abbrev=4)" >> "$GITHUB_ENV"
       - name: Docker metadata


### PR DESCRIPTION
Current container publishing is broken because of #749 

```
/usr/bin/docker buildx build --file RemoteSettings.Dockerfile --iidfile /home/runner/work/_temp/docker-actions-toolkit-WTbCI7/build-iidfile-89a8531826.txt --platform linux/amd64,linux/arm64 --tag mozilla/remote-settings:v32.10.0-10-g83eb --tag mozilla/remote-settings:latest --target production --metadata-file /home/runner/work/_temp/docker-actions-toolkit-WTbCI7/build-metadata-85bfe38eca.json --push .
ERROR: Multi-platform build is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
Learn more at https://docs.docker.com/go/build-multi-platform/
```

According to this https://github.com/docker/setup-buildx-action it should do the job