### PR TITLE
Fix #777: Add request-id filter to loggers

### DIFF
--- a/config/local.ini
+++ b/config/local.ini
@@ -158,6 +158,12 @@ keys = console
 [formatters]
 keys = color, json
 
+[filters]
+keys = request_id
+
+[filter_request_id]
+class = dockerflow.logging.RequestIdLogFilter
+
 [logger_root]
 level = INFO
 handlers = console
@@ -171,7 +177,8 @@ qualname = kinto
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
-formatter = color
+formatter = json
+filters = (request_id,)
 
 [formatter_json]
 class = kinto.core.JsonLogFormatter

--- a/config/testing.ini
+++ b/config/testing.ini
@@ -110,6 +110,12 @@ keys = console
 [formatters]
 keys = color
 
+[filters]
+keys = request_id
+
+[filter_request_id]
+class = dockerflow.logging.RequestIdLogFilter
+
 [logger_root]
 level = INFO
 handlers = console
@@ -124,6 +130,7 @@ class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
 formatter = color
+filters = (request_id,)
 
 [formatter_color]
 class = logging_color_formatter.ColorFormatter


### PR DESCRIPTION
Fix #777

```
$ kinto start --ini=config/local.ini
```

```
http :8888/v1/buckets/fefe "X-Request-Id: abcde"
```

Not working on arbitrary logs (🤔 ):
```
{"Timestamp": 1740662562147674880, "Type": "kinto.core.authorization", "Logger": "kinto", "Hostname": "obulo.local", "EnvVersion": "2.0", "Severity": 6, "Pid": 8337, "Fields": {"userid": "system.Everyone", "uri": "/buckets/fefe", "perm": "read", "msg": "Permission 'read' on '/buckets/fefe' not granted to 'system.Everyone'."}}
{"Timestamp": 1740662562147979008, "Type": "request.summary", "Logger": "kinto", "Hostname": "obulo.local", "EnvVersion": "2.0", "Severity": 6, "Pid": 8337, "Fields": {"agent": "HTTPie/3.2.4", "path": "/v1/buckets/fefe", "method": "GET", "rid": "abcde", "errno": 104, "time": "2025-02-27T14:22:42.147000", "code": 401, "t": 0}}

```