### PR TITLE
Fix #793: notify devs when build/publish fails

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -105,7 +105,7 @@ jobs:
           type: custom
           color: "#a72841"
           message: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
-          channel_id: ${{ env.SLACK_CHANNEL_ID_DEVELOPER }}
+          channel_id: ${{ vars.SLACK_CHANNEL_ID_DEVELOPER }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
   cronjobs_container:
@@ -164,7 +164,7 @@ jobs:
           type: custom
           color: "#a72841"
           message: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
-          channel_id: ${{ env.SLACK_CHANNEL_ID_DEVELOPER }}
+          channel_id: ${{ vars.SLACK_CHANNEL_ID_DEVELOPER }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
   browser_test_container:
@@ -219,7 +219,7 @@ jobs:
           type: custom
           color: "#a72841"
           message: "❤️ This is Mat trying Slack notif from GHA"
-          channel_id: ${{ env.SLACK_CHANNEL_ID_DEVELOPER }}
+          channel_id: ${{ vars.SLACK_CHANNEL_ID_DEVELOPER }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
       - name: Notify DEVs of build failure
         uses: mozilla-it/deploy-actions/slack@v3.13.0
@@ -231,5 +231,5 @@ jobs:
           type: custom
           color: "#a72841"
           message: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
-          channel_id: ${{ env.SLACK_CHANNEL_ID_DEVELOPER }}
+          channel_id: ${{ vars.SLACK_CHANNEL_ID_DEVELOPER }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -106,7 +106,7 @@ jobs:
           color: "#a72841"
           message: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
           channel_id: ${{ env.SLACK_CHANNEL_ID_DEVELOPER }}
-          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN_BUGID_1796141_20221019 }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
   cronjobs_container:
     env:
@@ -165,7 +165,7 @@ jobs:
           color: "#a72841"
           message: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
           channel_id: ${{ env.SLACK_CHANNEL_ID_DEVELOPER }}
-          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN_BUGID_1796141_20221019 }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
   browser_test_container:
     env:
@@ -224,4 +224,4 @@ jobs:
           color: "#a72841"
           message: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
           channel_id: ${{ env.SLACK_CHANNEL_ID_DEVELOPER }}
-          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN_BUGID_1796141_20221019 }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -213,6 +213,14 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha # Load cache from GitHub Actions
           cache-to: type=gha,mode=max # Save cache to GitHub Actions
+      - name: Try Slack token
+        uses: mozilla-it/deploy-actions/slack@v3.13.0
+        with:
+          type: custom
+          color: "#a72841"
+          message: "❤️ This is Mat trying Slack notif from GHA"
+          channel_id: ${{ env.SLACK_CHANNEL_ID_DEVELOPER }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
       - name: Notify DEVs of build failure
         uses: mozilla-it/deploy-actions/slack@v3.13.0
         if: failure()

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -214,13 +214,13 @@ jobs:
           cache-from: type=gha # Load cache from GitHub Actions
           cache-to: type=gha,mode=max # Save cache to GitHub Actions
       - name: Try Slack token
-        uses: mozilla-it/deploy-actions/slack@v3.13.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
-          type: custom
-          color: "#a72841"
-          message: "❤️ This is Mat trying Slack notif from GHA"
-          channel_id: ${{ vars.SLACK_CHANNEL_ID_DEVELOPER }}
-          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_CHANNEL_ID_DEVELOPER }}
+            text: "❤️ This is Mat trying Slack notif from GHA"
       - name: Notify DEVs of build failure
         uses: mozilla-it/deploy-actions/slack@v3.13.0
         if: failure()

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -216,11 +216,10 @@ jobs:
       - name: Try Slack token
         uses: slackapi/slack-github-action@v2.1.0
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
-            channel: ${{ vars.SLACK_CHANNEL_ID_DEVELOPER }}
-            text: "❤️ This is Mat trying Slack notif from GHA"
+            text: "❤️ This is Mat trying Slack notif from GHA (image=${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }})"
       - name: Notify DEVs of build failure
         uses: mozilla-it/deploy-actions/slack@v3.13.0
         if: failure()

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -95,6 +95,18 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha # Load cache from GitHub Actions
           cache-to: type=gha,mode=max # Save cache to GitHub Actions
+      - name: Notify DEVs of build failure
+        uses: mozilla-it/deploy-actions/slack@v3.13.0
+        if: failure()
+        with:
+          app_name: ${{ env.GAR_IMAGE_NAME }}
+          env_name: build
+          ref: ${{ env.LATEST_TAG }}
+          type: custom
+          color: "#a72841"
+          message: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
+          channel_id: ${{ env.SLACK_CHANNEL_ID_DEVELOPER }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN_BUGID_1796141_20221019 }}
 
   cronjobs_container:
     env:
@@ -142,6 +154,18 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha # Load cache from GitHub Actions
           cache-to: type=gha,mode=max # Save cache to GitHub Actions
+      - name: Notify DEVs of build failure
+        uses: mozilla-it/deploy-actions/slack@v3.13.0
+        if: failure()
+        with:
+          app_name: ${{ env.GAR_IMAGE_NAME }}
+          env_name: build
+          ref: ${{ env.LATEST_TAG }}
+          type: custom
+          color: "#a72841"
+          message: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
+          channel_id: ${{ env.SLACK_CHANNEL_ID_DEVELOPER }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN_BUGID_1796141_20221019 }}
 
   browser_test_container:
     env:
@@ -189,3 +213,15 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha # Load cache from GitHub Actions
           cache-to: type=gha,mode=max # Save cache to GitHub Actions
+      - name: Notify DEVs of build failure
+        uses: mozilla-it/deploy-actions/slack@v3.13.0
+        if: failure()
+        with:
+          app_name: ${{ env.GAR_IMAGE_NAME }}
+          env_name: build
+          ref: ${{ env.LATEST_TAG }}
+          type: custom
+          color: "#a72841"
+          message: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
+          channel_id: ${{ env.SLACK_CHANNEL_ID_DEVELOPER }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN_BUGID_1796141_20221019 }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -96,17 +96,13 @@ jobs:
           cache-from: type=gha # Load cache from GitHub Actions
           cache-to: type=gha,mode=max # Save cache to GitHub Actions
       - name: Notify DEVs of build failure
-        uses: mozilla-it/deploy-actions/slack@v3.13.0
         if: failure()
+        uses: slackapi/slack-github-action@v2.1.0
         with:
-          app_name: ${{ env.GAR_IMAGE_NAME }}
-          env_name: build
-          ref: ${{ env.LATEST_TAG }}
-          type: custom
-          color: "#a72841"
-          message: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
-          channel_id: ${{ vars.SLACK_CHANNEL_ID_DEVELOPER }}
-          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
 
   cronjobs_container:
     env:
@@ -155,17 +151,13 @@ jobs:
           cache-from: type=gha # Load cache from GitHub Actions
           cache-to: type=gha,mode=max # Save cache to GitHub Actions
       - name: Notify DEVs of build failure
-        uses: mozilla-it/deploy-actions/slack@v3.13.0
         if: failure()
+        uses: slackapi/slack-github-action@v2.1.0
         with:
-          app_name: ${{ env.GAR_IMAGE_NAME }}
-          env_name: build
-          ref: ${{ env.LATEST_TAG }}
-          type: custom
-          color: "#a72841"
-          message: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
-          channel_id: ${{ vars.SLACK_CHANNEL_ID_DEVELOPER }}
-          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
 
   browser_test_container:
     env:
@@ -213,22 +205,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha # Load cache from GitHub Actions
           cache-to: type=gha,mode=max # Save cache to GitHub Actions
-      - name: Try Slack token
+      - name: Notify DEVs of build failure
+        if: failure()
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "❤️ This is Mat trying Slack notif from GHA (image=${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }})"
-      - name: Notify DEVs of build failure
-        uses: mozilla-it/deploy-actions/slack@v3.13.0
-        if: failure()
-        with:
-          app_name: ${{ env.GAR_IMAGE_NAME }}
-          env_name: build
-          ref: ${{ env.LATEST_TAG }}
-          type: custom
-          color: "#a72841"
-          message: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
-          channel_id: ${{ vars.SLACK_CHANNEL_ID_DEVELOPER }}
-          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+            text: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."


### PR DESCRIPTION
Fix #793

Should we notify on success? I'd say we don't since we have Argo doing it already.

* [ ] Figure out if we're allowed to use `mozilla-it/deploy-actions/slack`
* [ ] Set `env.SLACK_CHANNEL_ID_DEVELOPER` in the `build` environment
* [ ] Set `env.SLACK_BOT_TOKEN_BUGID_1796141_20221019` in the `build` environment
