### PR TITLE
Debounce sync in `sync_megaphone` cronjob

### DIFF
--- a/cronjobs/src/commands/sync_megaphone.py
+++ b/cronjobs/src/commands/sync_megaphone.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import datetime, timezone
 
 import requests.auth
 
@@ -11,6 +12,10 @@ logger = logging.getLogger(__name__)
 
 BROADCASTER_ID = "remote-settings"
 CHANNEL_ID = "monitor_changes"
+
+
+def utcnow():
+    return datetime.now(timezone.utc)
 
 
 class BearerAuth(requests.auth.AuthBase):
@@ -70,6 +75,12 @@ def get_remotesettings_timestamp(uri):
 
 
 def sync_megaphone(event, context):
+    min_sync_interval = int(
+        os.getenv("MIN_SYNC_INTERVAL_SECONDS", "300")  # 5 min by default.
+    )
+    max_sync_interval = int(
+        os.getenv("MAX_SYNC_INTERVAL_SECONDS", "1200")  # 20 min by default.
+    )
     rs_server = event.get("server") or os.getenv("SERVER")
     rs_timestamp = get_remotesettings_timestamp(rs_server)
 
@@ -95,5 +106,30 @@ def sync_megaphone(event, context):
     if int(rs_timestamp) <= int(megaphone_timestamp):
         logger.info("Timestamps are in sync. Nothing to do.")
         return
+
+    # Do not push timestamp if one was published recently.
+    # This allows us to:
+    # - debounce many publications close together
+    # - decorrelate the frequency of the cronjob from the interval between two notifications
+    # - if changes are published continously for too long and megaphone becomes outdated, sync.
+    rs_age_seconds = (
+        utcnow() - datetime.fromtimestamp(int(rs_timestamp) / 1000, timezone.utc)
+    ).total_seconds()
+    megaphone_age_seconds = (
+        utcnow() - datetime.fromtimestamp(int(megaphone_timestamp) / 1000, timezone.utc)
+    ).total_seconds()
+
+    if (diff := min_sync_interval - rs_age_seconds) > 0:
+        print(f"A change was published recently (<{min_sync_interval}).", end=" ")
+        if megaphone_age_seconds < max_sync_interval:
+            print(
+                f"Megaphone is {megaphone_age_seconds} seconds old (<{max_sync_interval}). "
+                f"Can wait {diff} more seconds."
+            )
+            return
+        else:
+            print(
+                f"Megaphone is {megaphone_age_seconds} seconds old (>{max_sync_interval}). Sync!"
+            )
 
     megaphone_client.send_version(f'"{rs_timestamp}"')

--- a/cronjobs/tests/commands/test_sync_megaphone.py
+++ b/cronjobs/tests/commands/test_sync_megaphone.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import pytest
@@ -10,6 +11,8 @@ SERVER_URL = "https://fake-server.net/v1"
 MEGAPHONE_URL = "https://megaphone.tld/v1"
 BROADCAST_ID = "remote-settings"
 CHANNEL_ID = "monitor_changes"
+MIN_SYNC_INTERVAL_SECONDS = 100
+MAX_SYNC_INTERVAL_SECONDS = 300
 MONITOR_CHANGES_URI = f"{SERVER_URL}/buckets/monitor/collections/changes/changeset"
 MEGAPHONE_BROADCASTS_URI = f"{MEGAPHONE_URL}/broadcasts"
 MEGAPHONE_BROADCAST_URI = f"{MEGAPHONE_URL}/broadcasts/{BROADCAST_ID}/{CHANNEL_ID}"
@@ -24,9 +27,17 @@ def set_env_var():
             "MEGAPHONE_URL": MEGAPHONE_URL,
             "MEGAPHONE_READER_AUTH": "reader-token",
             "MEGAPHONE_BROADCASTER_AUTH": "broadcaster-token",
+            "MIN_SYNC_INTERVAL_SECONDS": str(MIN_SYNC_INTERVAL_SECONDS),
+            "MAX_SYNC_INTERVAL_SECONDS": str(MAX_SYNC_INTERVAL_SECONDS),
         },
     ):
         yield
+
+
+@pytest.fixture
+def mocked_now():
+    with mock.patch("commands.sync_megaphone.utcnow") as mocked:
+        yield mocked
 
 
 @responses.activate
@@ -113,7 +124,13 @@ def test_does_nothing_if_megaphone_is_newer():
 
 
 @responses.activate
-def test_sends_version_if_differs():
+def test_sends_version_if_less_than_debounce_seconds_and_megaphone_recent(mocked_now):
+    fake_now = datetime(2024, 3, 27, 13, 37, tzinfo=timezone.utc)
+    recent_timestamp = int(
+        (fake_now - timedelta(seconds=MIN_SYNC_INTERVAL_SECONDS - 10)).timestamp()
+        * 1000
+    )
+    mocked_now.return_value = fake_now
     responses.add(
         responses.GET,
         MONITOR_CHANGES_URI,
@@ -123,7 +140,7 @@ def test_sends_version_if_differs():
                     "id": "a",
                     "bucket": "main",
                     "collection": "cid",
-                    "last_modified": 10,
+                    "last_modified": recent_timestamp,
                 },
             ]
         },
@@ -134,7 +151,50 @@ def test_sends_version_if_differs():
         json={
             "code": 200,
             "broadcasts": {
-                "remote-settings/monitor_changes": '"5"',
+                "remote-settings/monitor_changes": f'"{recent_timestamp - 1100}"',
+                "test/broadcast2": "v0",
+            },
+        },
+    )
+
+    sync_megaphone(
+        event={},
+        context=None,
+    )
+
+    assert len(responses.calls) == 2
+    assert responses.calls[0].request.method == "GET"
+
+
+@responses.activate
+def test_sends_version_if_older_than_debounce_seconds(mocked_now):
+    fake_now = datetime(2024, 3, 27, 13, 37, tzinfo=timezone.utc)
+    old_timestamp = int(
+        (fake_now - timedelta(seconds=MIN_SYNC_INTERVAL_SECONDS + 10)).timestamp()
+        * 1000
+    )
+    mocked_now.return_value = fake_now
+    responses.add(
+        responses.GET,
+        MONITOR_CHANGES_URI,
+        json={
+            "changes": [
+                {
+                    "id": "a",
+                    "bucket": "main",
+                    "collection": "cid",
+                    "last_modified": old_timestamp + 42,
+                },
+            ]
+        },
+    )
+    responses.add(
+        responses.GET,
+        MEGAPHONE_BROADCASTS_URI,
+        json={
+            "code": 200,
+            "broadcasts": {
+                "remote-settings/monitor_changes": f'"{old_timestamp}"',
                 "test/broadcast2": "v0",
             },
         },
@@ -152,9 +212,63 @@ def test_sends_version_if_differs():
     assert len(responses.calls) == 3
     assert responses.calls[0].request.method == "GET"
     assert responses.calls[1].request.method == "GET"
-    assert responses.calls[2].request.body == '"10"'
+    assert responses.calls[2].request.method == "PUT"
+    assert responses.calls[2].request.body == f'"{old_timestamp + 42}"'
     assert responses.calls[1].request.headers["authorization"] == "Bearer reader-token"
     assert (
         responses.calls[2].request.headers["authorization"]
         == "Bearer broadcaster-token"
     )
+
+
+@responses.activate
+def test_sends_version_if_less_than_debounce_seconds_but_megaphone_is_old(mocked_now):
+    fake_now = datetime(2024, 3, 27, 13, 37, tzinfo=timezone.utc)
+    recent_timestamp = int(
+        (fake_now - timedelta(seconds=MIN_SYNC_INTERVAL_SECONDS - 10)).timestamp()
+        * 1000
+    )
+    outdated_timestamp = int(
+        (fake_now - timedelta(seconds=MAX_SYNC_INTERVAL_SECONDS + 10)).timestamp()
+        * 1000
+    )
+    mocked_now.return_value = fake_now
+    responses.add(
+        responses.GET,
+        MONITOR_CHANGES_URI,
+        json={
+            "changes": [
+                {
+                    "id": "a",
+                    "bucket": "main",
+                    "collection": "cid",
+                    "last_modified": recent_timestamp,
+                },
+            ]
+        },
+    )
+    responses.add(
+        responses.GET,
+        MEGAPHONE_BROADCASTS_URI,
+        json={
+            "code": 200,
+            "broadcasts": {
+                "remote-settings/monitor_changes": f'"{outdated_timestamp}"',
+                "test/broadcast2": "v0",
+            },
+        },
+    )
+    responses.add(
+        responses.PUT,
+        MEGAPHONE_BROADCAST_URI,
+    )
+
+    sync_megaphone(
+        event={},
+        context=None,
+    )
+
+    assert len(responses.calls) == 3
+    assert responses.calls[0].request.method == "GET"
+    assert responses.calls[1].request.method == "GET"
+    assert responses.calls[2].request.method == "PUT"

--- a/cronjobs/tests/commands/test_sync_megaphone.py
+++ b/cronjobs/tests/commands/test_sync_megaphone.py
@@ -1,160 +1,160 @@
-import unittest
+import os
+from unittest import mock
 
+import pytest
 import responses
 from commands.sync_megaphone import sync_megaphone
 
 
-class TestSyncMegaphone(unittest.TestCase):
-    server = "https://fake-server.net/v1"
-    megaphone_url = "https://megaphone.tld/v1"
-    megaphone_reader_auth = "reader-token"
-    megaphone_broadcaster_auth = "broadcaster-token"
-    broadcast_id = "remote-settings/monitor_changes"
+SERVER_URL = "https://fake-server.net/v1"
+MEGAPHONE_URL = "https://megaphone.tld/v1"
+BROADCAST_ID = "remote-settings"
+CHANNEL_ID = "monitor_changes"
+MONITOR_CHANGES_URI = f"{SERVER_URL}/buckets/monitor/collections/changes/changeset"
+MEGAPHONE_BROADCASTS_URI = f"{MEGAPHONE_URL}/broadcasts"
+MEGAPHONE_BROADCAST_URI = f"{MEGAPHONE_URL}/broadcasts/{BROADCAST_ID}/{CHANNEL_ID}"
 
-    def setUp(self):
-        self.source_monitor_changes_uri = (
-            f"{self.server}/buckets/monitor/collections/changes/changeset"
-        )
-        self.megaphone_broadcasts_uri = f"{self.megaphone_url}/broadcasts"
-        self.megaphone_broadcast_uri = (
-            f"{self.megaphone_url}/broadcasts/{self.broadcast_id}"
-        )
-        self.event = {
-            k: getattr(self, k)
-            for k in [
-                "server",
-                "megaphone_url",
-                "megaphone_reader_auth",
-                "megaphone_broadcaster_auth",
+
+@pytest.fixture(scope="module", autouse=True)
+def set_env_var():
+    with mock.patch.dict(
+        os.environ,
+        {
+            "SERVER": SERVER_URL,
+            "MEGAPHONE_URL": MEGAPHONE_URL,
+            "MEGAPHONE_READER_AUTH": "reader-token",
+            "MEGAPHONE_BROADCASTER_AUTH": "broadcaster-token",
+        },
+    ):
+        yield
+
+
+@responses.activate
+def test_does_nothing_if_up_to_date():
+    responses.add(
+        responses.GET,
+        MONITOR_CHANGES_URI,
+        json={
+            "changes": [
+                {
+                    "id": "a",
+                    "bucket": "main-preview",
+                    "collection": "cid",
+                    "last_modified": 10,
+                },
+                {
+                    "id": "b",
+                    "bucket": "main",
+                    "collection": "cid",
+                    "last_modified": 7,
+                },
             ]
-        }
-
-    @responses.activate
-    def test_does_nothing_if_up_to_date(self):
-        responses.add(
-            responses.GET,
-            self.source_monitor_changes_uri,
-            json={
-                "changes": [
-                    {
-                        "id": "a",
-                        "bucket": "main-preview",
-                        "collection": "cid",
-                        "last_modified": 10,
-                    },
-                    {
-                        "id": "b",
-                        "bucket": "main",
-                        "collection": "cid",
-                        "last_modified": 7,
-                    },
-                ]
+        },
+    )
+    responses.add(
+        responses.GET,
+        MEGAPHONE_BROADCASTS_URI,
+        json={
+            "code": 200,
+            "broadcasts": {
+                "remote-settings/monitor_changes": '"7"',
+                "test/broadcast2": "v0",
             },
-        )
-        responses.add(
-            responses.GET,
-            self.megaphone_broadcasts_uri,
-            json={
-                "code": 200,
-                "broadcasts": {
-                    "remote-settings/monitor_changes": '"7"',
-                    "test/broadcast2": "v0",
+        },
+    )
+
+    sync_megaphone(
+        event={},
+        context=None,
+    )
+
+    # No PUT on Megaphone API was sent.
+    assert len(responses.calls) == 2
+    assert responses.calls[0].request.method == "GET"
+    assert responses.calls[1].request.method == "GET"
+
+
+@responses.activate
+def test_does_nothing_if_megaphone_is_newer():
+    responses.add(
+        responses.GET,
+        MONITOR_CHANGES_URI,
+        json={
+            "changes": [
+                {
+                    "id": "b",
+                    "bucket": "main",
+                    "collection": "cid",
+                    "last_modified": 7,
                 },
+            ]
+        },
+    )
+    responses.add(
+        responses.GET,
+        MEGAPHONE_BROADCASTS_URI,
+        json={
+            "code": 200,
+            "broadcasts": {
+                "remote-settings/monitor_changes": '"8"',
             },
-        )
+        },
+    )
 
-        sync_megaphone(
-            event=self.event,
-            context=None,
-        )
+    sync_megaphone(
+        event={},
+        context=None,
+    )
 
-        # No PUT on Megaphone API was sent.
-        assert len(responses.calls) == 2
-        assert responses.calls[0].request.method == "GET"
-        assert responses.calls[1].request.method == "GET"
+    # No PUT on Megaphone API was sent.
+    assert len(responses.calls) == 2
+    assert responses.calls[0].request.method == "GET"
+    assert responses.calls[1].request.method == "GET"
 
-    @responses.activate
-    def test_does_nothing_if_megaphone_is_newer(self):
-        responses.add(
-            responses.GET,
-            self.source_monitor_changes_uri,
-            json={
-                "changes": [
-                    {
-                        "id": "b",
-                        "bucket": "main",
-                        "collection": "cid",
-                        "last_modified": 7,
-                    },
-                ]
-            },
-        )
-        responses.add(
-            responses.GET,
-            self.megaphone_broadcasts_uri,
-            json={
-                "code": 200,
-                "broadcasts": {
-                    "remote-settings/monitor_changes": '"8"',
+
+@responses.activate
+def test_sends_version_if_differs():
+    responses.add(
+        responses.GET,
+        MONITOR_CHANGES_URI,
+        json={
+            "changes": [
+                {
+                    "id": "a",
+                    "bucket": "main",
+                    "collection": "cid",
+                    "last_modified": 10,
                 },
+            ]
+        },
+    )
+    responses.add(
+        responses.GET,
+        MEGAPHONE_BROADCASTS_URI,
+        json={
+            "code": 200,
+            "broadcasts": {
+                "remote-settings/monitor_changes": '"5"',
+                "test/broadcast2": "v0",
             },
-        )
+        },
+    )
+    responses.add(
+        responses.PUT,
+        MEGAPHONE_BROADCAST_URI,
+    )
 
-        sync_megaphone(
-            event=self.event,
-            context=None,
-        )
+    sync_megaphone(
+        event={},
+        context=None,
+    )
 
-        # No PUT on Megaphone API was sent.
-        assert len(responses.calls) == 2
-        assert responses.calls[0].request.method == "GET"
-        assert responses.calls[1].request.method == "GET"
-
-    @responses.activate
-    def test_sends_version_if_differs(self):
-        responses.add(
-            responses.GET,
-            self.source_monitor_changes_uri,
-            json={
-                "changes": [
-                    {
-                        "id": "a",
-                        "bucket": "main",
-                        "collection": "cid",
-                        "last_modified": 10,
-                    },
-                ]
-            },
-        )
-        responses.add(
-            responses.GET,
-            self.megaphone_broadcasts_uri,
-            json={
-                "code": 200,
-                "broadcasts": {
-                    "remote-settings/monitor_changes": '"5"',
-                    "test/broadcast2": "v0",
-                },
-            },
-        )
-        responses.add(
-            responses.PUT,
-            self.megaphone_broadcast_uri,
-        )
-
-        sync_megaphone(
-            event=self.event,
-            context=None,
-        )
-
-        assert len(responses.calls) == 3
-        assert responses.calls[0].request.method == "GET"
-        assert responses.calls[1].request.method == "GET"
-        assert responses.calls[2].request.body == '"10"'
-        assert (
-            responses.calls[1].request.headers["authorization"] == "Bearer reader-token"
-        )
-        assert (
-            responses.calls[2].request.headers["authorization"]
-            == "Bearer broadcaster-token"
-        )
+    assert len(responses.calls) == 3
+    assert responses.calls[0].request.method == "GET"
+    assert responses.calls[1].request.method == "GET"
+    assert responses.calls[2].request.body == '"10"'
+    assert responses.calls[1].request.headers["authorization"] == "Bearer reader-token"
+    assert (
+        responses.calls[2].request.headers["authorization"]
+        == "Bearer broadcaster-token"
+    )


### PR DESCRIPTION
With this change we could run the cronjob every minute, instead of syncing arbitrarily every 5min.

If there was no recent change, it would sync immediately.
And there were recent changes, it would wait and group them.

It is not rare that several changes are published with little time between them, this PR would group them.
```json
  {
    "source": "main-workspace/nimbus-mobile-experiments",
    "timestamp": 1743108392727,
    "datetime": "2025-03-27T20:46:32.726174+00:00",
    "by": "ldap:jstermac@mozilla.com",
    "changes": {
      "create": 1
    }
  },
  {
    "source": "main-workspace/nimbus-mobile-experiments",
    "timestamp": 1743108285290,
    "datetime": "2025-03-27T20:44:45.289323+00:00",
    "by": "ldap:jstermac@mozilla.com",
    "changes": {
      "create": 1
    }
  },
  {
    "source": "main-workspace/nimbus-mobile-experiments",
    "timestamp": 1743108194926,
    "datetime": "2025-03-27T20:43:14.924530+00:00",
    "by": "ldap:sescalante@mozilla.com",
    "changes": {
      "create": 1
    }
  },
```