### PR TITLE
Fix #830: remove query in a loop using new storage method of kinto 20.2.0

### DIFF
--- a/kinto-remote-settings/tests/changes/test_utils.py
+++ b/kinto-remote-settings/tests/changes/test_utils.py
@@ -1,41 +1,25 @@
 import unittest
 from unittest import mock
 
-from kinto_remote_settings.changes.utils import changes_object
+from kinto_remote_settings.changes.utils import change_entry_id
 from pyramid.request import Request
 
 
-class ChangesRecordTest(unittest.TestCase):
+class ChangesEntryIdTest(unittest.TestCase):
     def test_single_hardcoded(self):
         request = Request.blank(path="/")
         request.route_path = mock.Mock()
         request.route_path.return_value = "/buckets/a/collections/b"
-        request.registry = mock.Mock()
-        request.registry.settings = {}
-        timestamp = 1525457597166
-        entry = changes_object(request, "a", "b", timestamp)
 
-        assert entry == {
-            "bucket": "a",
-            "collection": "b",
-            "host": "",
-            "id": "9527d115-6191-fa49-a530-8fbfc4997755",
-            "last_modified": timestamp,
-        }
+        entry = change_entry_id(request, "", "a", "b")
+
+        assert entry == "9527d115-6191-fa49-a530-8fbfc4997755"
 
     def test_another_hardcoded(self):
         request = Request.blank(path="/")
         request.route_path = mock.Mock()
         request.route_path.return_value = "/buckets/a/collections/b"
-        request.registry = mock.Mock()
-        request.registry.settings = {"http_host": "https://localhost:443"}
-        timestamp = 1525457597166
-        entry = changes_object(request, "a", "b", timestamp)
 
-        assert entry == {
-            "bucket": "a",
-            "collection": "b",
-            "host": "https://localhost:443",
-            "id": "fa48a96d-1600-f561-8645-3395acb08a5a",
-            "last_modified": timestamp,
-        }
+        entry = change_entry_id(request, "https://localhost:443", "a", "b")
+
+        assert entry == "fa48a96d-1600-f561-8645-3395acb08a5a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1082,14 +1082,14 @@ referencing = ">=0.31.0"
 
 [[package]]
 name = "kinto"
-version = "20.1.0"
+version = "20.2.0"
 description = "Kinto Web Service - Store, Sync, Share, and Self-Host."
 optional = false
 python-versions = "*"
 groups = ["main", "kinto-remote-settings"]
 files = [
-    {file = "kinto-20.1.0-py3-none-any.whl", hash = "sha256:14956b1788f9e89f37178aab3a5c33cd985e7acab2cd4b123f1f6a6c7f32c992"},
-    {file = "kinto-20.1.0.tar.gz", hash = "sha256:3b211d1380f82bfbabe74d95cf6f1f92ddf920a38e15bc441dcb01b30e50aee5"},
+    {file = "kinto-20.2.0-py3-none-any.whl", hash = "sha256:89fb2bf538b9f1eb7d228fadb27d30bd4e2b4c446bcaba7eac085c4be1667777"},
+    {file = "kinto-20.2.0.tar.gz", hash = "sha256:6921264d7adaa4b34c97c4cf5bf9b8351bf83425aed8f172a800e6c47d7935f9"},
 ]
 
 [package.dependencies]
@@ -2893,4 +2893,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <3.14"
-content-hash = "b2d577780968cc0b66e88418ff6c260fbc195bea70723c02329f671c89396108"
+content-hash = "b5ae13c03ec99d8d19ce54de1512970f6a34b9b7fb7fc359d4908b22d7c089b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ python = ">=3.11, <3.14"
 canonicaljson-rs = "0.7.1"
 cryptography = "44.0.2"
 ecdsa = "0.19.1"
-kinto = {version = "^20.1.0", extras = ["postgresql","memcached","monitoring"]}
+kinto = {version = "^20.2.0", extras = ["postgresql","memcached","monitoring"]}
 kinto-attachment = "7.0.0"
 kinto-emailer = "3.0.4"
 requests-hawk = "1.2.1"


### PR DESCRIPTION
Fix #830

* [x] Release https://github.com/Kinto/kinto/pull/3518 in kinto 20.2.0
* [x] poetry lock

With PROD database, loading `curl 'localhost:8888/v1/buckets/monitor/collections/changes/changeset?_expected=42&_since="1743184921243"'`:

## Before: 413 DB queries

## After: 1 DB query
(99.76% improvement 🤣)


