### PR TITLE
Updating changes config in sample files, test, and read-me to reflect kinto behavior

### DIFF
--- a/config/local.ini
+++ b/config/local.ini
@@ -88,12 +88,12 @@ mail.debug_mailer = true
 #
 
 kinto.changes.resources =
-    /buckets/main
-    /buckets/main-preview
-    /buckets/security-state
-    /buckets/security-state-preview
-    /buckets/blocklists
-    /buckets/blocklists-preview
+    /buckets/main/
+    /buckets/main-preview/
+    /buckets/security-state/
+    /buckets/security-state-preview/
+    /buckets/blocklists/
+    /buckets/blocklists-preview/
 
 kinto.signer.resources =
     /buckets/main-workspace           -> /buckets/main-preview           -> /buckets/main

--- a/config/testing.ini
+++ b/config/testing.ini
@@ -56,12 +56,12 @@ kinto.attachment.folder = {bucket_id}/{collection_id}
 #
 
 kinto.changes.resources =
-    /buckets/main
-    /buckets/main-preview
-    /buckets/security-state
-    /buckets/security-state-preview
-    /buckets/blocklists
-    /buckets/blocklists-preview
+    /buckets/main/
+    /buckets/main-preview/
+    /buckets/security-state/
+    /buckets/security-state-preview/
+    /buckets/blocklists/
+    /buckets/blocklists-preview/
 
 kinto.signer.resources =
     /buckets/main-workspace           -> /buckets/main-preview           -> /buckets/main

--- a/kinto-remote-settings/README.rst
+++ b/kinto-remote-settings/README.rst
@@ -20,9 +20,9 @@ Settings
 
 .. code-block :: ini
 
-    # List of buckets/collections to show:
-    kinto.changes.resources = /buckets/settings
-                              /buckets/blocklists/collections/certificates
+    # List of buckets/collections to show (starts with URI match):
+    kinto.changes.resources = /buckets/settings/
+                              /buckets/blocklists/collections/certificates 
 
 Cache Control
 -------------

--- a/kinto-remote-settings/tests/changes/config.ini
+++ b/kinto-remote-settings/tests/changes/config.ini
@@ -11,7 +11,7 @@ kinto.bucket_read_principals =
 kinto.bucket_write_principals =
     basicauth:c6c27f0c7297ba7d4abd2a70c8a2cb88a06a3bb793817ef2c85fe8a709b08022
 
-kinto.changes.resources = /buckets/blocklists
+kinto.changes.resources = /buckets/blocklists/
 kinto.changes.excluded_collections = /buckets/blocklists/collections/excluded
 # Since redirect disabled.
 kinto.changes.since_max_age_days = -1

--- a/kinto-remote-settings/tests/changes/test_changes.py
+++ b/kinto-remote-settings/tests/changes/test_changes.py
@@ -169,7 +169,7 @@ class UpdateChangesTest(BaseWebTest, unittest.TestCase):
             "description": "Track modifications of records in Kinto and store "
             "the collection timestamps into a specific bucket "
             "and collection.",
-            "collections": ["/buckets/blocklists"],
+            "collections": ["/buckets/blocklists/"],
             "url": "http://kinto.readthedocs.io/en/latest/tutorials/"
             "synchronisation.html#polling-for-remote-changes",
             "version": __version__,


### PR DESCRIPTION
Updating the `changes.resources` config in our tests, sample config, and read-me as this is a "starts with" match on URI's now.