### PR TITLE
Fix #842: prevent automatically deleted collections to show up in monitor/changes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -214,7 +214,7 @@
         "filename": "kinto-remote-settings/tests/signer/config.ini",
         "hashed_secret": "1dd36a56a08a3517e72339117edb26b43d3db2ab",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 26
       }
     ],
     "kinto-remote-settings/tests/signer/ecdsa.private.pem": [
@@ -275,5 +275,5 @@
       }
     ]
   },
-  "generated_at": "2025-02-24T09:47:28Z"
+  "generated_at": "2025-04-02T20:40:42Z"
 }

--- a/kinto-remote-settings/tests/signer/config.ini
+++ b/kinto-remote-settings/tests/signer/config.ini
@@ -4,6 +4,7 @@ kinto.userid_hmac_secret = aujourd'hui encore, il fait beau en bretagne.
 multiauth.policies = basicauth
 
 kinto.includes = kinto_remote_settings.signer
+                 kinto_remote_settings.changes
                  kinto_emailer
 
 signer.to_review_enabled = true
@@ -15,6 +16,9 @@ kinto.signer.resources =
     /buckets/stage -> /buckets/preview -> /buckets/prod
     /buckets/main-workspace -> /buckets/main-preview -> /buckets/main
     /buckets/security-state-workspace/collections/onecrl -> /buckets/security-state/collections/onecrl
+
+kinto.changes.resources = /buckets/preview
+                          /buckets/prod
 
 kinto.signer.signer_backend = kinto_remote_settings.signer.backends.autograph
 kinto.signer.autograph.server_url = http://localhost:8000

--- a/kinto-remote-settings/tests/signer/test_plugin_setup.py
+++ b/kinto-remote-settings/tests/signer/test_plugin_setup.py
@@ -759,15 +759,23 @@ class SourceCollectionHardDeletion(BaseWebTest, PatchAutographMixin, unittest.Te
         )
 
     def test_deleted_collection_does_not_show_up_in_monitored_changes(self):
-        monitored = self.app.get("/buckets/monitor/collections/changes/changeset?_expected=0")
-        cids = set(f"{e['bucket']}/{e['collection']}" for e in monitored.json["changes"])
+        monitored = self.app.get(
+            "/buckets/monitor/collections/changes/changeset?_expected=0"
+        )
+        cids = set(
+            f"{e['bucket']}/{e['collection']}" for e in monitored.json["changes"]
+        )
         assert "preview/a" in cids
         assert "prod/a" in cids
 
         self.app.delete("/buckets/stage/collections/a", headers=self.headers)
 
-        monitored = self.app.get("/buckets/monitor/collections/changes/changeset?_expected=0")
-        cids = set(f"{e['bucket']}/{e['collection']}" for e in monitored.json["changes"])
+        monitored = self.app.get(
+            "/buckets/monitor/collections/changes/changeset?_expected=0"
+        )
+        cids = set(
+            f"{e['bucket']}/{e['collection']}" for e in monitored.json["changes"]
+        )
         assert "preview/a" not in cids
         assert "prod/a" not in cids
 

--- a/kinto-remote-settings/tests/signer/test_plugin_setup.py
+++ b/kinto-remote-settings/tests/signer/test_plugin_setup.py
@@ -758,6 +758,19 @@ class SourceCollectionHardDeletion(BaseWebTest, PatchAutographMixin, unittest.Te
             status=404,
         )
 
+    def test_deleted_collection_does_not_show_up_in_monitored_changes(self):
+        monitored = self.app.get("/buckets/monitor/collections/changes/changeset?_expected=0")
+        cids = set(f"{e['bucket']}/{e['collection']}" for e in monitored.json["changes"])
+        assert "preview/a" in cids
+        assert "prod/a" in cids
+
+        self.app.delete("/buckets/stage/collections/a", headers=self.headers)
+
+        monitored = self.app.get("/buckets/monitor/collections/changes/changeset?_expected=0")
+        cids = set(f"{e['bucket']}/{e['collection']}" for e in monitored.json["changes"])
+        assert "preview/a" not in cids
+        assert "prod/a" not in cids
+
 
 class ExpandedSettingsTest(BaseWebTest, PatchAutographMixin, unittest.TestCase):
     @classmethod

--- a/poetry.lock
+++ b/poetry.lock
@@ -1082,14 +1082,14 @@ referencing = ">=0.31.0"
 
 [[package]]
 name = "kinto"
-version = "20.2.0"
+version = "20.3.0"
 description = "Kinto Web Service - Store, Sync, Share, and Self-Host."
 optional = false
 python-versions = "*"
 groups = ["main", "kinto-remote-settings"]
 files = [
-    {file = "kinto-20.2.0-py3-none-any.whl", hash = "sha256:89fb2bf538b9f1eb7d228fadb27d30bd4e2b4c446bcaba7eac085c4be1667777"},
-    {file = "kinto-20.2.0.tar.gz", hash = "sha256:6921264d7adaa4b34c97c4cf5bf9b8351bf83425aed8f172a800e6c47d7935f9"},
+    {file = "kinto-20.3.0-py3-none-any.whl", hash = "sha256:6adef3f2c33ab3fa2351d7a12f2c5b181b3aa7d334244e18143a637be1f928ab"},
+    {file = "kinto-20.3.0.tar.gz", hash = "sha256:5117d4ad0a06f6e48c94e75f1eeb6f752720076fd302c19c151e761bc5fc6b89"},
 ]
 
 [package.dependencies]
@@ -2893,4 +2893,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <3.14"
-content-hash = "b5ae13c03ec99d8d19ce54de1512970f6a34b9b7fb7fc359d4908b22d7c089b1"
+content-hash = "c4f93ee85afbc3e1bb39aa7d6382bc3e45aff52611be585dc54aa6ec84644071"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ python = ">=3.11, <3.14"
 canonicaljson-rs = "0.7.1"
 cryptography = "44.0.2"
 ecdsa = "0.19.1"
-kinto = {version = "^20.2.0", extras = ["postgresql","memcached","monitoring"]}
+kinto = {version = "^20.3.0", extras = ["postgresql","memcached","monitoring"]}
 kinto-attachment = "7.0.0"
 kinto-emailer = "3.0.4"
 requests-hawk = "1.2.1"


### PR DESCRIPTION
Fix #842 

* [x] Reproduce issue
* [x] Run "purge" instead of just deleting from storage
* [x] Requires memory backend fix from https://github.com/Kinto/kinto/pull/3520