### PR TITLE
Skip push notifications for nimbus-preview

### DIFF
--- a/cronjobs/src/commands/sync_megaphone.py
+++ b/cronjobs/src/commands/sync_megaphone.py
@@ -65,7 +65,7 @@ def get_remotesettings_timestamp(uri):
         max(
             e["last_modified"]
             for e in changeset["changes"]
-            if "preview" not in e["bucket"]
+            if "-preview" not in f"{e['bucket']}/{e['collection']}"
         )
     )
 

--- a/cronjobs/tests/commands/test_sync_megaphone.py
+++ b/cronjobs/tests/commands/test_sync_megaphone.py
@@ -47,10 +47,17 @@ def test_does_nothing_if_up_to_date():
         MONITOR_CHANGES_URI,
         json={
             "changes": [
+                # Skips -preview entries
                 {
                     "id": "a",
                     "bucket": "main-preview",
                     "collection": "cid",
+                    "last_modified": 10,
+                },
+                {
+                    "id": "a",
+                    "bucket": "main",
+                    "collection": "cid-preview",
                     "last_modified": 10,
                 },
                 {


### PR DESCRIPTION
A more elegant way would have been to do https://github.com/mozilla-it/webservices-infra/pull/4566
But @freshstrangemusic said that some change would have to be done if the `nimbus-preview` collection is not listed in the monitor/changes endpoint.

Slightly modifying the `sync_megaphone` cronjob without fully hardcoding the nimbus collection seems acceptable and will stop boardcasting push notifs everytime the team publishes changes for the QA team.

The collection has very frequent changes:
```
curl -s https://telescope.prod.webservices.mozgcp.net/checks/remotesettings-prod/latest-approvals | jq '.data[]
  | select(.source | contains("nimbus-preview"))
  | ((.datetime // "") | tostring)
    + " +" + ((.changes.create // "0") | tostring)
    + " ~" + ((.changes.update // "0") | tostring)
    + " -" + ((.changes.delete // "0") | tostring)'

"2025-04-16T21:56:53.805889+00:00 +1 ~0 -0"
"2025-04-16T21:51:40.756317+00:00 +0 ~0 -1"
"2025-04-16T21:45:53.532507+00:00 +1 ~0 -0"
"2025-04-16T21:45:09.839424+00:00 +0 ~0 -1"
"2025-04-16T21:30:51.937506+00:00 +1 ~0 -0"
"2025-04-16T20:11:11.030227+00:00 +1 ~0 -0"
"2025-04-16T20:10:41.050448+00:00 +0 ~0 -1"
```