### PR TITLE
Add log fields for data approval events

### DIFF
--- a/config/local.ini
+++ b/config/local.ini
@@ -172,6 +172,7 @@ qualname = kinto
 class = kinto.core.StreamHandlerWithRequestID
 args = (sys.stderr,)
 level = NOTSET
+formatter = json
 
 [formatter_json]
 class = kinto.core.JsonLogFormatter


### PR DESCRIPTION
Since we want to query logs from BigQuery, it would be handy to have fields values instead of parsing messages strings.

This PR adds them:

```
web-1  | {"Timestamp": 1746544617302661376, "Type": "kinto_remote_settings.signer.listeners", "Logger": "kinto", "Hostname": "ceb4a6cb3e22", "EnvVersion": "2.0", "Severity": 6, "Pid": 10, "Fields": {"user_id": "account:reviewer", "collection_id": "main-workspace/integration-tests", "action": "approve", "changes_count": 2, "rid": "12234245-3927-4d6f-bcc9-f527ad8028b9", "msg": "account:reviewer approved 2 changes on integration-tests"}}
```