### PR TITLE
Add flush plugin to testing config

### DIFF
--- a/config/testing.ini
+++ b/config/testing.ini
@@ -12,6 +12,7 @@ kinto.project_name = Remote Settings TESTING
 
 kinto.includes = kinto.plugins.admin
                  kinto.plugins.history
+                 kinto.plugins.flush
                  kinto_emailer
                  kinto_attachment
                  kinto_remote_settings


### PR DESCRIPTION
Calling `POST /__flush__` to reset the full content can be useful when testing clients etc.