### PR TITLE
Ref #897 - Adjust server release process to only re-tag on release rather than rebuild

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -112,22 +112,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha # Load cache from GitHub Actions
           cache-to: type=gha,mode=max # Save cache to GitHub Actions
-      - name: Set up crane # copied from https://github.com/imjasonh/setup-crane/blob/main/action.yml
-        shell: bash
-        run: |
-          set -ex
-
-          out=crane
-          os=${{ runner.os }}
-          tag=$(curl -s -u "username:${{ github.token }}" https://api.github.com/repos/google/go-containerregistry/releases/latest | jq -r '.tag_name')
-          arch=$(uname -m)
-          tmp=$(mktemp -d)
-          cd "${tmp}"
-          curl -fsL "https://github.com/google/go-containerregistry/releases/download/${tag}/go-containerregistry_${os}_${arch}.tar.gz" | tar xz "${out}"
-          chmod +x "${tmp}/${out}"
-          PATH=${PATH}:${tmp}
-          echo "${tmp}" >> "${GITHUB_PATH}"
-          echo "${{ github.token }}" | crane auth login ghcr.io --username "dummy" --password-stdin
       - name: Copy from Google Artifact Registry to Docker Hub
         if: github.event_name != 'pull_request'
         env:
@@ -135,10 +119,8 @@ jobs:
             ${{ steps.metahub.outputs.tags }}
           SRC: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/autograph:sha-${{ github.sha }}
         run: |
-          crane digest "${SRC}"
-          crane manifest "${SRC}"
           for tag in $TAGS; do
-            crane copy "${SRC}" "${tag}"
+            docker buildx imagetools create --tag "${tag}" "${SRC}" 
           done
       - name: Copy image from Google Artifact Registry to Google Artifact Registry as semver tag
         if: ${{ github.event_name == 'release' }}
@@ -147,10 +129,8 @@ jobs:
             ${{ steps.metagar.outputs.tags }}
           SRC: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/autograph:sha-${{ github.sha }}
         run: |
-          crane digest "${SRC}"
-          crane manifest "${SRC}"
           for tag in $TAGS; do
-            crane copy "${SRC}" "${tag}"
+            docker buildx imagetools create --tag "${tag}" "${SRC}" 
           done
       - name: Notify DEVs of build failure
         if: failure()

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -152,14 +152,14 @@ jobs:
           for tag in $TAGS; do
             crane copy "${SRC}" "${tag}"
           done
-      # - name: Notify DEVs of build failure
-      #   if: failure()
-      #   uses: slackapi/slack-github-action@v2.1.0
-      #   with:
-      #     webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #     webhook-type: incoming-webhook
-      #     payload: |
-      #       text: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
+      - name: Notify DEVs of build failure
+        if: failure()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
 
   cronjobs_container:
     env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -93,6 +93,7 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.gcp_auth.outputs.access_token }}
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -128,6 +129,7 @@ jobs:
           echo "${tmp}" >> "${GITHUB_PATH}"
           echo "${{ github.token }}" | crane auth login ghcr.io --username "dummy" --password-stdin
       - name: Copy from Google Artifact Registory to Docker Hub
+        if: github.event_name != 'pull_request'
         env:
           TAGS: |
             ${{ steps.metahub.outputs.tags }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,17 +50,31 @@ jobs:
             "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > ./version.json
             # Show complete version.json for debugging
             cat ./version.json
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
+      - name: Extract metadata for Google Artifact Registry
+        id: metagar
         uses: docker/metadata-action@v5
         with:
+          flavor:
+            # don't automatically tag with `latest`; we do this conditionally in the `tags` section
+            latest=false
+          images: |
+            ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.GAR_IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.LATEST_TAG }},enable=${{ github.event_name == 'push' }}
+            type=sha,format=long,enable=${{ github.event_name == 'push' }}
+            type=semver,pattern={{raw}},enable=${{ github.event_name == 'release' }}
+      - name: Docker Metadata for Docker Hub
+        id: metahub
+        uses: docker/metadata-action@v5
+        with:
+          flavor:
+            # don't automatically tag with `latest`; we do this conditionally in the `tags` section
+            latest=false
           images: |
             ${{ env.DOCKERHUB_IMAGE_NAME }}
-            ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.GAR_IMAGE_NAME }}
-          # https://github.com/marketplace/actions/docker-metadata-action#tags-input
           tags: |
-            type=raw,value=latest
-            type=raw,value=${{ env.LATEST_TAG }}
+            type=semver,pattern={{raw}},enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Authenticate on GCP
@@ -83,18 +97,59 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push to GAR and Docker Hub
+      - name: Build and push to GAR
+        if: ${{ github.event_name == 'push' }}
         uses: docker/build-push-action@v6
         with:
           context: .
           file: RemoteSettings.Dockerfile
+          sbom: true
           target: production  # See multi-stage build
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.metagar.outputs.tags }}
+          labels: ${{ steps.metagar.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha # Load cache from GitHub Actions
           cache-to: type=gha,mode=max # Save cache to GitHub Actions
+      - name: Set up crane # copied from https://github.com/imjasonh/setup-crane/blob/main/action.yml
+        shell: bash
+        run: |
+          set -ex
+
+          out=crane
+          os=${{ runner.os }}
+          tag=$(curl -s -u "username:${{ github.token }}" https://api.github.com/repos/google/go-containerregistry/releases/latest | jq -r '.tag_name')
+          arch=$(uname -m)
+          tmp=$(mktemp -d)
+          cd ${tmp}
+          curl -fsL https://github.com/google/go-containerregistry/releases/download/${tag}/go-containerregistry_${os}_${arch}.tar.gz | tar xz ${out}
+          chmod +x ${tmp}/${out}
+          PATH=${PATH}:${tmp}
+          echo "${tmp}" >> $GITHUB_PATH
+          echo "${{ github.token }}" | crane auth login ghcr.io --username "dummy" --password-stdin
+      - name: Copy from Google Artifact Registory to Docker Hub
+        env:
+          TAGS: |
+            ${{ steps.metahub.outputs.tags }}
+          SRC: ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY}}/autograph:sha-${{ github.sha }}
+        run: |
+          crane digest $SRC
+          crane manifest $SRC
+          for tag in $TAGS; do
+            crane copy $SRC $tag
+          done
+      - name: Copy image from Google Artifact Registory to Google Artifact Registory as semver tag
+        if: ${{ github.event_name == 'release' }}
+        env:
+          TAGS: |
+            ${{ steps.metagar.outputs.tags }}
+          SRC: ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY}}/autograph:sha-${{ github.sha }}
+        run: |
+          crane digest $SRC
+          crane manifest $SRC
+          for tag in $TAGS; do
+            crane copy $SRC $tag
+          done
       - name: Notify DEVs of build failure
         if: failure()
         uses: slackapi/slack-github-action@v2.1.0
@@ -160,6 +215,7 @@ jobs:
             text: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
 
   browser_test_container:
+    if: ${{ github.event_name == 'push' }} # we use latest tag, not needed on release
     env:
       GAR_IMAGE_NAME: remote-settings-browser-tests
       LATEST_TAG: ""  # Set after checkout step

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -93,7 +93,6 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.gcp_auth.outputs.access_token }}
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -131,7 +131,7 @@ jobs:
         env:
           TAGS: |
             ${{ steps.metahub.outputs.tags }}
-          SRC: ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY}}/autograph:sha-${{ github.sha }}
+          SRC: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/autograph:sha-${{ github.sha }}
         run: |
           crane digest $SRC
           crane manifest $SRC
@@ -143,7 +143,7 @@ jobs:
         env:
           TAGS: |
             ${{ steps.metagar.outputs.tags }}
-          SRC: ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY}}/autograph:sha-${{ github.sha }}
+          SRC: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/autograph:sha-${{ github.sha }}
         run: |
           crane digest $SRC
           crane manifest $SRC

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -128,7 +128,7 @@ jobs:
           PATH=${PATH}:${tmp}
           echo "${tmp}" >> "${GITHUB_PATH}"
           echo "${{ github.token }}" | crane auth login ghcr.io --username "dummy" --password-stdin
-      - name: Copy from Google Artifact Registory to Docker Hub
+      - name: Copy from Google Artifact Registry to Docker Hub
         if: github.event_name != 'pull_request'
         env:
           TAGS: |
@@ -140,7 +140,7 @@ jobs:
           for tag in $TAGS; do
             crane copy "${SRC}" "${tag}"
           done
-      - name: Copy image from Google Artifact Registory to Google Artifact Registory as semver tag
+      - name: Copy image from Google Artifact Registry to Google Artifact Registry as semver tag
         if: ${{ github.event_name == 'release' }}
         env:
           TAGS: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,8 +7,9 @@ on:
   push:
     branches:
       - main
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+  release:
+    types:
+      - released
 
 permissions:
   contents: read
@@ -121,11 +122,11 @@ jobs:
           tag=$(curl -s -u "username:${{ github.token }}" https://api.github.com/repos/google/go-containerregistry/releases/latest | jq -r '.tag_name')
           arch=$(uname -m)
           tmp=$(mktemp -d)
-          cd ${tmp}
-          curl -fsL https://github.com/google/go-containerregistry/releases/download/${tag}/go-containerregistry_${os}_${arch}.tar.gz | tar xz ${out}
-          chmod +x ${tmp}/${out}
+          cd "${tmp}"
+          curl -fsL "https://github.com/google/go-containerregistry/releases/download/${tag}/go-containerregistry_${os}_${arch}.tar.gz" | tar xz "${out}"
+          chmod +x "${tmp}/${out}"
           PATH=${PATH}:${tmp}
-          echo "${tmp}" >> $GITHUB_PATH
+          echo "${tmp}" >> "${GITHUB_PATH}"
           echo "${{ github.token }}" | crane auth login ghcr.io --username "dummy" --password-stdin
       - name: Copy from Google Artifact Registory to Docker Hub
         env:
@@ -133,10 +134,10 @@ jobs:
             ${{ steps.metahub.outputs.tags }}
           SRC: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/autograph:sha-${{ github.sha }}
         run: |
-          crane digest $SRC
-          crane manifest $SRC
+          crane digest "${SRC}"
+          crane manifest "${SRC}"
           for tag in $TAGS; do
-            crane copy $SRC $tag
+            crane copy "${SRC}" "${tag}"
           done
       - name: Copy image from Google Artifact Registory to Google Artifact Registory as semver tag
         if: ${{ github.event_name == 'release' }}
@@ -145,19 +146,19 @@ jobs:
             ${{ steps.metagar.outputs.tags }}
           SRC: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/autograph:sha-${{ github.sha }}
         run: |
-          crane digest $SRC
-          crane manifest $SRC
+          crane digest "${SRC}"
+          crane manifest "${SRC}"
           for tag in $TAGS; do
-            crane copy $SRC $tag
+            crane copy "${SRC}" "${tag}"
           done
-      - name: Notify DEVs of build failure
-        if: failure()
-        uses: slackapi/slack-github-action@v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            text: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
+      # - name: Notify DEVs of build failure
+      #   if: failure()
+      #   uses: slackapi/slack-github-action@v2.1.0
+      #   with:
+      #     webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #     webhook-type: incoming-webhook
+      #     payload: |
+      #       text: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
 
   cronjobs_container:
     env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -192,7 +192,7 @@ jobs:
           service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Login to GAR
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
@@ -202,7 +202,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: cronjobs/
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha # Load cache from GitHub Actions
@@ -217,7 +217,6 @@ jobs:
             text: "⚠️  Build of ${{ env.GAR_IMAGE_NAME }}:${{ env.LATEST_TAG }} failed. Please review logs and correct issues."
 
   browser_test_container:
-    if: ${{ github.event_name == 'push' }} # we use latest tag, not needed on release
     env:
       GAR_IMAGE_NAME: remote-settings-browser-tests
       LATEST_TAG: ""  # Set after checkout step
@@ -248,7 +247,7 @@ jobs:
           service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Login to GAR
-        if: github.event_name != 'pull_request'
+        if: ${{ github.event_name == 'push' }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
@@ -258,7 +257,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: browser-tests/
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha # Load cache from GitHub Actions


### PR DESCRIPTION
Ref #897 - re-tagging the existing server image on release rather than rebuilding.
Core cronjob and browser tests images only use `latest` tags, adjusting so they aren't rebuilt on release.