### PR TITLE
Do not automerge kinto-admin PRs

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -99,4 +99,3 @@ jobs:
             --base "main" \
             --head "$BRANCH_NAME" \
             --label "dependencies")"
-          gh pr merge --auto --squash "$PR_REF"

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -93,9 +93,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: updates/kinto-admin-${{ steps.latest_release_version.outputs.version }}
         run: |
-          PR_REF="$(gh pr create \
+          gh pr create \
             --title "Update Kinto Admin version to ${{ steps.latest_release_version.outputs.version }}" \
             --body "Updating kinto-admin to latest release" \
             --base "main" \
             --head "$BRANCH_NAME" \
-            --label "dependencies")"
+            --label "dependencies"


### PR DESCRIPTION
Would that allow our publish action to run for the commit on `main` after merge? 


**update**: Add context:
- we have a Github action that runs on schedule every day and creates PRs ([like this one](https://github.com/mozilla/remote-settings/pull/945)) if a new version of the Kinto Admin was published
- Side note: on these PRs, Github Actions don't run, because the PR is created by a Github Action ([example](https://github.com/orgs/community/discussions/57484))
- The PR is created with "automerge" option, so as soon it gets approved, it's merged automatically
- When this happened last time ([ref](https://github.com/mozilla/remote-settings/pull/945#pullrequestreview-3019082035)), the publish github action didn't run for the merge commit that landed on `main` (https://github.com/mozilla/remote-settings/commit/3a9c879ecedb5691dfd2a36e2332278365260f20)
- When we tagged a release, there was no image published in GAR for this commit (because the action hadn't run), and it failed ([logs](https://github.com/mozilla/remote-settings/actions/runs/16287074975/job/45994042422))
- I was wondering whether we could solve this by removing the automerge option, hoping that in this case the merge commit author would be a human and not a GH Action, and thus the publish action would run as on usual PRs