### PR TITLE
Fix #977 - Returning 400 responses to clients when `_expected` value is less than `_since` value

### DIFF
--- a/kinto-remote-settings/tests/changes/test_changes.py
+++ b/kinto-remote-settings/tests/changes/test_changes.py
@@ -238,13 +238,11 @@ class OldSinceRedirectTest(BaseWebTest, unittest.TestCase):
         resp = self.app.get(self.changes_uri + f"?_since={timestamp}")
         assert resp.status_code == 307
 
-    def test_redirects_and_drops_since_if_rewind(self):
-        resp = self.app.get(self.changes_uri + "?_since=42&_expected=1")
-        assert resp.status_code == 307
-        assert (
-            resp.headers["Location"]
-            == "https://cdn-host/v1/buckets/monitor/collections/changes/records?_expected=1"
+    def test_bad_request_if_rewind(self):
+        resp = self.app.get(
+            self.changes_uri + "?_since=42&_expected=1", expect_errors=True
         )
+        assert resp.status_code == 400
 
     def test_redirects_keep_other_querystring_params(self):
         resp = self.app.get(self.changes_uri + "?_since=42&_foo=%22123456%22")

--- a/kinto-remote-settings/tests/changes/test_changeset.py
+++ b/kinto-remote-settings/tests/changes/test_changeset.py
@@ -239,6 +239,15 @@ class MonitorChangesetViewTest(BaseWebTest, unittest.TestCase):
             "/buckets/monitor/collections/changes/changeset?_expected=42"
         )
 
+    def test_changeset_redirects_if_rewind(self):
+        resp = self.app.get(self.changeset_uri + '&_since="43"')
+
+        assert resp.status_code == 307
+        assert resp.headers["Location"] == (
+            "https://www.kinto-storage.org/v1"
+            "/buckets/monitor/collections/changes/changeset?_expected=42"
+        )
+
     def test_limit_is_supported(self):
         resp = self.app.get(self.changeset_uri + "&_limit=1", headers=self.headers)
         assert len(resp.json["changes"]) == 1
@@ -256,6 +265,7 @@ class MonitorChangesetViewTest(BaseWebTest, unittest.TestCase):
             headers=self.headers,
         )
         data = resp.json
+        print(data)
         assert data["changes"][0]["collection"] == "certificates"
 
         self.app.post_json(

--- a/kinto-remote-settings/tests/changes/test_changeset.py
+++ b/kinto-remote-settings/tests/changes/test_changeset.py
@@ -260,7 +260,6 @@ class MonitorChangesetViewTest(BaseWebTest, unittest.TestCase):
             headers=self.headers,
         )
         data = resp.json
-        print(data)
         assert data["changes"][0]["collection"] == "certificates"
 
         self.app.post_json(

--- a/kinto-remote-settings/tests/changes/test_changeset.py
+++ b/kinto-remote-settings/tests/changes/test_changeset.py
@@ -239,14 +239,9 @@ class MonitorChangesetViewTest(BaseWebTest, unittest.TestCase):
             "/buckets/monitor/collections/changes/changeset?_expected=42"
         )
 
-    def test_changeset_redirects_if_rewind(self):
-        resp = self.app.get(self.changeset_uri + '&_since="43"')
-
-        assert resp.status_code == 307
-        assert resp.headers["Location"] == (
-            "https://www.kinto-storage.org/v1"
-            "/buckets/monitor/collections/changes/changeset?_expected=42"
-        )
+    def test_changeset_bad_request_if_rewind(self):
+        resp = self.app.get(self.changeset_uri + '&_since="43"', expect_errors=True)
+        assert resp.status_code == 400
 
     def test_limit_is_supported(self):
         resp = self.app.get(self.changeset_uri + "&_limit=1", headers=self.headers)


### PR DESCRIPTION
Ref #977 - Rejecting requests with `_expected` values lower than `_since` values. This will prevent a rare problem with them trying to go back in time.

- [x] Add logic to check `_expected` against `_since` and return a 400 response
- [x] Add unit tests