### PR TITLE
Switching stale 400 response to 204 so gcp cdn can cache it

### DIFF
--- a/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
@@ -8,7 +8,6 @@ from kinto.authorization import RouteFactory
 from kinto.core import Service, resource
 from kinto.core import utils as core_utils
 from kinto.core.cornice.validators import colander_validator
-from kinto.core.errors import raise_invalid
 from kinto.core.storage import Filter, Sort
 from kinto.core.storage import exceptions as storage_exceptions
 from kinto.core.storage.memory import extract_object_set
@@ -187,12 +186,15 @@ def _handle_stale_expected(request):
 
     # Check if client is trying to go back in time, return 400 response
     if qs_expected > 0 and qs_expected < qs_since:
-        raise_invalid(
-            request,
-            name="_expected",
-            location="querystring",
-            description="`_expected` parameter cannot be lower than `_since`",
+        response = httpexceptions.HTTPNoContent()
+        cache_seconds = int(
+            request.registry.settings.get(
+                "changes.since_max_age_redirect_ttl_seconds", 86400
+            )
         )
+        if cache_seconds >= 0:
+            response.cache_expires(cache_seconds)
+        raise response
 
 
 def _handle_old_since_redirect(request):

--- a/kinto-remote-settings/tests/changes/test_changes.py
+++ b/kinto-remote-settings/tests/changes/test_changes.py
@@ -239,10 +239,8 @@ class OldSinceRedirectTest(BaseWebTest, unittest.TestCase):
         assert resp.status_code == 307
 
     def test_bad_request_if_rewind(self):
-        resp = self.app.get(
-            self.changes_uri + "?_since=42&_expected=1", expect_errors=True
-        )
-        assert resp.status_code == 400
+        resp = self.app.get(self.changes_uri + "?_since=42&_expected=1")
+        assert resp.status_code == 204
 
     def test_redirects_keep_other_querystring_params(self):
         resp = self.app.get(self.changes_uri + "?_since=42&_foo=%22123456%22")

--- a/kinto-remote-settings/tests/changes/test_changeset.py
+++ b/kinto-remote-settings/tests/changes/test_changeset.py
@@ -255,8 +255,8 @@ class MonitorChangesetViewTest(BaseWebTest, unittest.TestCase):
         )
 
     def test_changeset_bad_request_if_rewind(self):
-        resp = self.app.get(self.changeset_uri + '&_since="43"', expect_errors=True)
-        assert resp.status_code == 400
+        resp = self.app.get(self.changeset_uri + '&_since="43"')
+        assert resp.status_code == 204
 
     def test_limit_is_supported(self):
         resp = self.app.get(self.changeset_uri + "&_limit=1", headers=self.headers)


### PR DESCRIPTION
Ref #977 - Switching response code from 400 to 204 so gcp cdn can cache correctly