### PR TITLE
Ref #977 - Moving back to 400 responses for stale expected values after fastly migration

### DIFF
--- a/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
@@ -186,7 +186,7 @@ def _handle_stale_expected(request):
 
     # Check if client is trying to go back in time, return 400 response
     if qs_expected > 0 and qs_expected < qs_since:
-        response = httpexceptions.HTTPNoContent()
+        response = httpexceptions.HTTPBadRequest()
         cache_seconds = int(
             request.registry.settings.get(
                 "changes.since_max_age_redirect_ttl_seconds", 86400

--- a/kinto-remote-settings/tests/changes/test_changes.py
+++ b/kinto-remote-settings/tests/changes/test_changes.py
@@ -239,8 +239,10 @@ class OldSinceRedirectTest(BaseWebTest, unittest.TestCase):
         assert resp.status_code == 307
 
     def test_bad_request_if_rewind(self):
-        resp = self.app.get(self.changes_uri + "?_since=42&_expected=1")
-        assert resp.status_code == 204
+        resp = self.app.get(
+            self.changes_uri + "?_since=42&_expected=1", expect_errors=True
+        )
+        assert resp.status_code == 400
 
     def test_redirects_keep_other_querystring_params(self):
         resp = self.app.get(self.changes_uri + "?_since=42&_foo=%22123456%22")

--- a/kinto-remote-settings/tests/changes/test_changeset.py
+++ b/kinto-remote-settings/tests/changes/test_changeset.py
@@ -255,8 +255,8 @@ class MonitorChangesetViewTest(BaseWebTest, unittest.TestCase):
         )
 
     def test_changeset_bad_request_if_rewind(self):
-        resp = self.app.get(self.changeset_uri + '&_since="43"')
-        assert resp.status_code == 204
+        resp = self.app.get(self.changeset_uri + '&_since="43"', expect_errors=True)
+        assert resp.status_code == 400
 
     def test_limit_is_supported(self):
         resp = self.app.get(self.changeset_uri + "&_limit=1", headers=self.headers)


### PR DESCRIPTION
Ref #977 - Moving back to 400 responses for stale expected values after fastly migration

Leaving in draft for now, will merge when we are ready to test.