### PR TITLE
Git reader: serve attachments with their mimetypes

### DIFF
--- a/git-reader/Dockerfile
+++ b/git-reader/Dockerfile
@@ -7,7 +7,7 @@ ENV PIP_NO_CACHE_DIR=off \
     VIRTUAL_ENV=/opt/.venv \
     PATH="/opt/.venv/bin:$PATH"
 
-RUN apt-get update && apt-get -y install git git-lfs rsync util-linux
+RUN apt-get update && apt-get -y install git git-lfs rsync util-linux media-types
 
 # Install Poetry
 RUN python -m venv $VIRTUAL_ENV && \
@@ -31,7 +31,7 @@ RUN poetry install --no-root
 
 COPY --chown=app:app run.sh .
 RUN chmod +x run.sh
-COPY --chown=app:app app.py .
+COPY --chown=app:app app.py mimetypes.txt ./
 
 USER app
 

--- a/git-reader/mimetypes.txt
+++ b/git-reader/mimetypes.txt
@@ -1,0 +1,17 @@
+# Extend what Debian provides
+# Or make sure it is consistent on Mac OS.
+# https://mimetype.io/all-types
+application/json			json
+application/geo+json		geojson
+image/avif					avif
+image/webp					webp
+video/webm					webm
+application/x-fluent		ftl
+application/wasm			wasm
+application/x-pem-file		pem
+image/svg+xml				svg
+image/x-icon				ico
+image/png					png
+image/jpeg					jpg jpeg
+text/plain					txt
+application/xml				xml


### PR DESCRIPTION
Alternatively we could save the original attachment metadata in tree. But this seems a reasonable approach.
It does not work on attachments that are uploaded without file extension, but these are really rare (tracking protection lists for example).
Note that for our readers, clients would still download attachments from the GCS via the CDN, with their appropriate mimetype.

Related: https://github.com/Kinto/kinto-admin/issues/3367