### PR TITLE
Fix reading SSH keys from home in `git_export`

### DIFF
--- a/cronjobs/Dockerfile
+++ b/cronjobs/Dockerfile
@@ -31,5 +31,11 @@ COPY --from=build $VIRTUAL_ENV $VIRTUAL_ENV
 WORKDIR /app
 ADD src ./
 
+RUN chown 10001:10001 /app && \
+    groupadd --gid 10001 app && \
+    useradd --no-create-home --uid 10001 --gid 10001 --home-dir /app app
+
+USER app
+
 ENTRYPOINT ["/app/main.py"]
 CMD ["help"]

--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -36,7 +36,9 @@ REPO_OWNER = config("REPO_OWNER", default="mozilla")
 REPO_NAME = config("REPO_NAME", default="remote-settings-data")
 GITHUB_USERNAME = config("GITHUB_USERNAME", default="")
 GITHUB_TOKEN = config("GITHUB_TOKEN", default="")
-SSH_PRIVKEY_PATH = config("SSH_PRIVKEY_PATH", default="~/.ssh/id_ed25519")
+SSH_PRIVKEY_PATH = os.path.expanduser(
+    config("SSH_PRIVKEY_PATH", default="~/.ssh/id_ed25519")
+)
 SSH_KEY_PASSPHRASE = config("SSH_KEY_PASSPHRASE", default="")
 
 # Internal parameters
@@ -49,7 +51,9 @@ GIT_REMOTE_URL = config(
     "GIT_REMOTE_URL",
     default=f"{GIT_SSH_USERNAME}@github.com:{REPO_OWNER}/{REPO_NAME}.git",
 )
-SSH_PUBKEY_PATH = config("SSH_PUBKEY_PATH", default=f"{SSH_PRIVKEY_PATH}.pub")
+SSH_PUBKEY_PATH = os.path.expanduser(
+    config("SSH_PUBKEY_PATH", default=f"{SSH_PRIVKEY_PATH}.pub")
+)
 
 # Constants
 GIT_REF_PREFIX = "v1/"
@@ -69,8 +73,8 @@ def git_export(event, context):
     )
     credentials = Keypair(
         GIT_SSH_USERNAME,
-        os.path.expanduser(SSH_PUBKEY_PATH),
-        os.path.expanduser(SSH_PRIVKEY_PATH),
+        SSH_PUBKEY_PATH,
+        SSH_PRIVKEY_PATH,
         SSH_KEY_PASSPHRASE,
     )
     callbacks = RemoteCallbacks(credentials=credentials)


### PR DESCRIPTION
Keys are mounted in `/app/.ssh/*`

But without this the container tries to read from `/root`.

This adds the `app` user pattern that we have everywhere, and shows expanded paths of keys in logs.