### PR TITLE
Fix cronjobs help command

### DIFF
--- a/cronjobs/Dockerfile
+++ b/cronjobs/Dockerfile
@@ -19,7 +19,7 @@ COPY pyproject.toml poetry.lock ./
 RUN $POETRY_HOME/bin/poetry install --no-root
 
 
-FROM python:3.13.2
+FROM python:3.13.2-slim
 
 ENV PATH="/opt/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1 \

--- a/cronjobs/src/commands/build_bundles.py
+++ b/cronjobs/src/commands/build_bundles.py
@@ -136,7 +136,9 @@ def sync_cloud_storage(
 
 def build_bundles(event, context):
     """
-    Main command entry point that:
+    Build and upload bundles of changesets and attachments.
+
+    This command:
     - fetches all collections changesets
     - builds a `changesets.json.mozlz4`
     - builds a `startup.json.mozlz4`

--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -61,7 +61,7 @@ GIT_EMAIL = _email.rstrip(">")
 
 def git_export(event, context):
     """
-    Main entrypoint
+    Export Remote Settings data to a Git repository.
     """
     print(f"Git remote URL {GIT_REMOTE_URL}")
     print(

--- a/cronjobs/src/main.py
+++ b/cronjobs/src/main.py
@@ -43,7 +43,10 @@ def help_(**kwargs):
         for entrypoint in ENTRYPOINTS
     ]
     func_listed = "\n - ".join(
-        [f"{white_bold(f.__name__)}: {f.__doc__}" for f in commands]
+        [
+            f"{white_bold(f.__name__)}: {f.__doc__.strip().splitlines()[0]}"
+            for f in commands
+        ]
     )
     print(
         f"""


### PR DESCRIPTION
Before:
```
python main.py help

Remote Settings lambdas.

Available commands:

 - git_export:
    Main entrypoint

 - backport_records: Backport records creations, updates and deletions from one collection to another.
 - build_bundles:
    Main command entry point that:
    - fetches all collections changesets
    - builds a `changesets.json.mozlz4`
    - builds a `startup.json.mozlz4`
    - fetches attachments of all collections with bundle flag
    - builds `{bid}--{cid}.zip` for each of them
    - send the bundles to the Cloud storage bucket

 - refresh_signature: Refresh the signatures of each collection.
 - purge_history: Purge old history entries on a regular basis.

```

After:
```
python main.py help

Remote Settings lambdas.

Available commands:

 - git_export: Export Remote Settings data to a Git repository.
 - backport_records: Backport records creations, updates and deletions from one collection to another.
 - build_bundles: Build and upload bundles of changesets and attachments.
 - refresh_signature: Refresh the signatures of each collection.
 - purge_history: Purge old history entries on a regular basis.
```

+ drive by fix for base image