### PR TITLE
Add some details whether SSH keys are not readable or missing

### DIFF
--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -71,6 +71,11 @@ def git_export(event, context):
     print(
         f"Use SSH key {SSH_PUBKEY_PATH} with {'*' * len(SSH_KEY_PASSPHRASE) if SSH_KEY_PASSPHRASE else 'empty'} passphrase"
     )
+    for key in (SSH_PUBKEY_PATH, SSH_PRIVKEY_PATH):
+        if not os.path.exists(key):
+            raise FileNotFoundError(f"SSH key file {key} does not exist")
+        if not os.access(key, os.R_OK):
+            raise PermissionError(f"SSH key file {key} is not readable")
     credentials = Keypair(
         GIT_SSH_USERNAME,
         SSH_PUBKEY_PATH,


### PR DESCRIPTION
Logs tell us:

```
  File "/app/commands/_git_export_git_tools.py", line 38, in clone_or_fetch
    pygit2.clone_repository(repo_url, repo_path, callbacks=callbacks)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/.venv/lib/python3.13/site-packages/pygit2/__init__.py", line 541, in clone_repository
    payload.check_error(err)
    ~~~~~~~~~~~~~~~~~~~^^^^^
  File "/opt/.venv/lib/python3.13/site-packages/pygit2/callbacks.py", line 111, in check_error
    check_error(error_code)
    ~~~~~~~~~~~^^^^^^^^^^^^
  File "/opt/.venv/lib/python3.13/site-packages/pygit2/errors.py", line 67, in check_error
    raise GitError(message)
_pygit2.GitError: failed to authenticate SSH session: Unable to open public key file
```

Apparently pygit2 does not differentiate whether the key exists but is unreadable. 

This patch will help us diagnose what is going on with our secret mount 