### PR TITLE
git-export: fix job when remote has no branch

### DIFF
--- a/cronjobs/src/commands/_git_export_git_tools.py
+++ b/cronjobs/src/commands/_git_export_git_tools.py
@@ -28,7 +28,10 @@ def clone_or_fetch(
             raise ValueError(
                 f"Remote URL {remote.url} of work dir {repo_path} does not match {repo_url}"
             )
-        print("Head was at", repo.head.target)
+        if not repo.raw_listall_references():
+            print("No branches or tags found in the repository.")
+        else:
+            print("Head was at", repo.head.target)
         print(f"Fetching from {repo_url}...")
         remote.fetch(callbacks=callbacks, prune=True)
         reset_repo(repo, callbacks=callbacks)

--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -83,7 +83,10 @@ def git_export(event, context):
     # TODO: use PGP key to sign commits
 
     repo = clone_or_fetch(GIT_REMOTE_URL, WORK_DIR, callbacks=callbacks)
-    print("Head is now at", repo.head.target)
+    if not repo.raw_listall_references():
+        print("No branches or tags found in the repository.")
+    else:
+        print("Head is now at", repo.head.target)
 
     try:
         changed_attachments, changed_branches, changed_tags = asyncio.run(


### PR DESCRIPTION
```
$ export SSH_KEY_PASSPHRASE
$ export GITHUB_TOKEN
$ REPO_NAME=remote-settings-data-stage GITHUB_USERNAME=leplatrem SERVER="https://firefox.settings.services.mozilla.com/v1" python src/main.py git_export
Git remote URL git@github.com:mozilla/remote-settings-data-stage.git
Use SSH key /Users/mathieu/.ssh/id_ed25519.pub with ************ passphrase
Work dir /tmp/git-export.git already exists, skipping clone.
Traceback (most recent call last):
  File "/Users/mathieu/Code/Mozilla/remote-settings/cronjobs/src/main.py", line 105, in <module>
    sys.exit(main(*sys.argv[1:]))
             ^^^^^^^^^^^^^^^^^^^
  File "/Users/mathieu/Code/Mozilla/remote-settings/cronjobs/src/main.py", line 101, in main
    return run(entrypoint)
           ^^^^^^^^^^^^^^^
  File "/Users/mathieu/Code/Mozilla/remote-settings/cronjobs/src/main.py", line 82, in run
    return command(event, context)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mathieu/Code/Mozilla/remote-settings/cronjobs/src/commands/git_export.py", line 85, in git_export
    repo = clone_or_fetch(GIT_REMOTE_URL, WORK_DIR, callbacks=callbacks)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mathieu/Code/Mozilla/remote-settings/cronjobs/src/commands/_git_export_git_tools.py", line 34, in clone_or_fetch
    print("Head was at", repo.head.target)
                         ^^^^^^^^^
_pygit2.GitError: reference 'refs/heads/master' not found
```