### PR TITLE
git export: test LFS credentials on startup and fail early

### DIFF
--- a/cronjobs/src/commands/_git_export_lfs.py
+++ b/cronjobs/src/commands/_git_export_lfs.py
@@ -170,6 +170,48 @@ def _github_lfs_verify_upload(
     r.raise_for_status()
 
 
+def _base64_auth_header(username: str, token: str) -> str:
+    creds = f"{username}:{token}".encode("utf-8")
+    return f"Basic {base64.b64encode(creds).decode('ascii')}"
+
+
+def github_lfs_test_credentials(
+    github_username: str,
+    github_token: str,
+    repo_owner: str,
+    repo_name: str,
+    timeout: float = HTTP_TIMEOUT_BATCH_SECONDS,
+) -> bool:
+    """
+    Test GitHub LFS credentials by making a dummy batch request.
+    """
+    if not github_token.startswith("github_pat_"):
+        print(
+            "Warning: It looks like the provided GitHub token is not a PAT (personal access token)."
+        )
+    authz = _base64_auth_header(github_username, github_token)
+    # Fetch profile of the authenticated user to verify token works.
+    resp = requests.get(
+        "https://api.github.com/user",
+        headers={"Authorization": authz, "Accept": "application/vnd.github.v3+json"},
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    user_data = resp.json()
+    print(
+        f"Authenticated as GitHub user: {user_data.get('login')} (id={user_data.get('id')})"
+    )
+    print(user_data)
+    github_lfs_batch_request(
+        auth_header=authz,
+        objects=[],
+        operation="upload",
+        repo_owner=repo_owner,
+        repo_name=repo_name,
+        timeout=timeout,
+    )
+
+
 def github_lfs_batch_upload_many(
     objects: Iterable[tuple[str, int, str]],  # (sha256_hex, size, source_url),
     github_username: str,
@@ -184,8 +226,7 @@ def github_lfs_batch_upload_many(
 
     objects: iterable of (oid_hex:str, size:int, src_url:str)
     """
-    creds = f"{github_username}:{github_token}".encode("utf-8")
-    authz = f"Basic {base64.b64encode(creds).decode('ascii')}"
+    authz = _base64_auth_header(github_username, github_token)
 
     chunks = list(itertools.batched(objects, GITHUB_MAX_LFS_BATCH_SIZE))
     total_chunks = len(chunks)

--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -26,6 +26,7 @@ from ._git_export_git_tools import (
 from ._git_export_lfs import (
     fetch_and_hash,
     github_lfs_batch_upload_many,
+    github_lfs_test_credentials,
 )
 
 
@@ -81,6 +82,14 @@ def git_export(event, context):
     )
     callbacks = RemoteCallbacks(credentials=credentials)
     # TODO: use PGP key to sign commits
+
+    print(f"Testing GitHub Token for {GITHUB_USERNAME} on {REPO_OWNER}/{REPO_NAME}...")
+    github_lfs_test_credentials(
+        github_username=GITHUB_USERNAME,
+        github_token=GITHUB_TOKEN,
+        repo_owner=REPO_OWNER,
+        repo_name=REPO_NAME,
+    )
 
     repo = clone_or_fetch(GIT_REMOTE_URL, WORK_DIR, callbacks=callbacks)
     if not repo.raw_listall_references():

--- a/cronjobs/tests/commands/test_git_export.py
+++ b/cronjobs/tests/commands/test_git_export.py
@@ -51,7 +51,8 @@ def mock_repo_sync_content():
 @pytest.fixture
 def mock_github_lfs():
     with mock.patch.object(git_export, "github_lfs_batch_upload_many") as mock_lfs:
-        yield mock_lfs
+        with mock.patch.object(git_export, "github_lfs_test_credentials"):
+            yield mock_lfs
 
 
 @pytest.fixture


### PR DESCRIPTION
This prevents the misconfigured cronjob to fetch and build the repo every 10min.
It's also more convenient for developers to try out configuration locally 😊 
