### PR TITLE
Add missing explicit `pyjwt`

### DIFF
--- a/cronjobs/poetry.lock
+++ b/cronjobs/poetry.lock
@@ -631,6 +631,24 @@ files = [
 cffi = ">=2.0"
 
 [[package]]
+name = "pyjwt"
+version = "2.10.1"
+description = "JSON Web Token implementation in Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb"},
+    {file = "pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953"},
+]
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
+dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+
+[[package]]
 name = "python-decouple"
 version = "3.8"
 description = "Strict separation of settings from code."
@@ -769,4 +787,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <3.15"
-content-hash = "768221f1704888ba138f2a4e578d7c5d292e7d96bb5b746129d3f0d251f20222"
+content-hash = "bb65e836a816e45d03ef858a32c11e09e170244e2c22ba683418176ce1388905"

--- a/cronjobs/pyproject.toml
+++ b/cronjobs/pyproject.toml
@@ -14,6 +14,7 @@ sentry_sdk = "^2.20.0"
 google-cloud-storage = "^3.0.0"
 lz4 = "^4.3.3"
 pygit2 = "^1.19.0"
+pyjwt = "^2.10.1"
 
 [tool.pytest_env]
 # Environment variables (thanks to pytest-env)

--- a/poetry.lock
+++ b/poetry.lock
@@ -690,6 +690,7 @@ google-cloud-storage = "^3.0.0"
 kinto-http = "^11.8.0"
 lz4 = "^4.3.3"
 pygit2 = "^1.19.0"
+pyjwt = "^2.10.1"
 python-decouple = "^3.8"
 requests = "^2.32.4"
 sentry_sdk = "^2.20.0"
@@ -2210,7 +2211,7 @@ version = "2.10.1"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["git-reader"]
+groups = ["cronjobs", "git-reader"]
 files = [
     {file = "PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb"},
     {file = "pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953"},


### PR DESCRIPTION
Tests work because it is a sub-dep of `cryptography`.

But cronjobs container does not have it.

```
((.venv) ) ➜  remote-settings git:(main) ✗ docker compose run cronjobs git-export
Unknown function 'git-export'
Traceback (most recent call last):
  File "/app/main.py", line 105, in <module>
    sys.exit(main(*sys.argv[1:]))
             ~~~~^^^^^^^^^^^^^^^
  File "/app/main.py", line 98, in main
    help_()
    ~~~~~^^
  File "/app/main.py", line 42, in help_
    getattr(importlib.import_module(f"commands.{entrypoint}"), entrypoint)
            ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1398, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1342, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 938, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 762, in exec_module
  File "<frozen importlib._bootstrap>", line 491, in _call_with_frames_removed
  File "/app/commands/git_export.py", line 26, in <module>
    from ._git_export_lfs import (
    ...<3 lines>...
    )
  File "/app/commands/_git_export_lfs.py", line 10, in <module>
    import jwt
ModuleNotFoundError: No module named 'jwt'

```