### PR TITLE
git-export: Skip bundle if no attachment in collection

### DIFF
--- a/cronjobs/src/commands/_git_export_lfs.py
+++ b/cronjobs/src/commands/_git_export_lfs.py
@@ -413,4 +413,4 @@ def github_lfs_batch_upload_many(
         print(
             f"LFS: {len(to_upload)} uploaded and {len(to_verify)} verified in chunk {idx}/{total_chunks}"
         )
-        time.sleep(SLOW_DOWN_SECONDS) # avoid hitting rate limits
+        time.sleep(SLOW_DOWN_SECONDS)  # avoid hitting rate limits

--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -325,6 +325,9 @@ async def repo_sync_content(
     for changeset in all_changesets:
         if not changeset["metadata"].get("attachment", {}).get("bundle", False):
             continue
+        has_attachment = any(r.get("attachment") for r in changeset["changes"])
+        if not has_attachment:
+            continue
         metadata = changeset["metadata"]
         bundles_locations.append(f"bundles/{metadata['bucket']}--{metadata['id']}.zip")
     for location in bundles_locations:


### PR DESCRIPTION
In DEV, bundles are enabled for `security-state/intermediates` but the collection is empty.

The `build_bundles` job skips the archive:

https://github.com/mozilla/remote-settings/blob/d74ce7f14d5216262e98af2c60c55cd330860d17/cronjobs/src/commands/build_bundles.py#L172

So, the git-export should do the same, otherwise it will try to fetch a bundle that doesn't exist:

```
...
...
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://attachments.dev.remote-settings.nonprod.webservices.mozgcp.net/bundles/security-state--intermediates.zip
```