### PR TITLE
gitupdate without any changes should not result in an error exit code

### DIFF
--- a/git-reader/run.sh
+++ b/git-reader/run.sh
@@ -67,6 +67,7 @@ cmd_gitupdate() {
         result=$?
         if [ $result -eq 1 ]; then
             log "No update available"
+            exit 0
         else
             log "Error during update (exit code $result)"
         fi


### PR DESCRIPTION
Right now if `gitupdate` runs fir the `git-reader` container and has no updates, it returns a non-zero exit code.
Since this is a no-op, it should just return 0 for the exit code.