### PR TITLE
Fix expire orphan attachment job, event hold not required

### DIFF
--- a/cronjobs/src/commands/expire_orphan_attachments.py
+++ b/cronjobs/src/commands/expire_orphan_attachments.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 from datetime import datetime, timezone
 
@@ -15,6 +16,7 @@ REALM = os.getenv("REALM", "test")
 STORAGE_BUCKET_NAME = os.getenv(
     "STORAGE_BUCKET_NAME", f"remote-settings-{REALM}-{ENVIRONMENT}-attachments"
 )
+BATCH_SIZE = int(os.getenv("BATCH_SIZE", "100"))
 
 
 def expire_orphan_attachments(event, context):
@@ -30,43 +32,44 @@ def expire_orphan_attachments(event, context):
     all_changesets = fetch_all_changesets(client)
 
     attachments = set()
+    total_size = 0
     for changeset in all_changesets:
         for record in changeset["changes"]:
             if attachments_info := record.get("attachment"):
                 attachments.add(attachments_info["location"])
-    print(f"Found {len(attachments)} referenced attachments.")
+                total_size += attachments_info["size"]
+    print(
+        f"Found {len(attachments)} referenced attachments. Total size: {total_size / (1024 * 1024):.2f}MB"
+    )
 
     storage_client = storage.Client()
     bucket = storage_client.bucket(STORAGE_BUCKET_NAME)
 
-    blobs = bucket.list_blobs()  # Recursive by default
-    with storage_client.batch():
-        for blob in blobs:
-            if blob.name in attachments:
-                continue  # This attachment is still referenced.
-
-            if blob.name.startswith("bundles/"):
-                continue  # Bundles are regenerated reguarly.
-
-            # Skip "directory placeholders" (zero-length folder markers)
-            if blob.name.endswith("/"):
-                continue
-
-            if blob.custom_time is not None:
-                if VERBOSE:
-                    print(
-                        f"{blob.name} already has custom_time set to {blob.custom_time}"
-                    )
-                continue
-
-            if DRY_RUN:
+    to_update = []
+    for blob in bucket.list_blobs():
+        if blob.name in attachments or blob.name.startswith("bundles/"):
+            continue
+        if blob.custom_time is not None:
+            if VERBOSE:
                 print(
-                    f"[DRY RUN] Would mark orphan attachment gs://{STORAGE_BUCKET_NAME}/{blob.name} for deletion"
+                    f"Skipping blob gs://{STORAGE_BUCKET_NAME}/{blob.name} already marked for deletion at {blob.custom_time}"
                 )
-                continue
-
+            continue
+        if DRY_RUN:
             print(
-                f"Marking orphan attachment gs://{STORAGE_BUCKET_NAME}/{blob.name} for deletion"
+                f"[DRY RUN] Would mark orphan attachment gs://{STORAGE_BUCKET_NAME}/{blob.name} for deletion"
             )
-            blob.custom_time = datetime.now(timezone.utc)
-            blob.patch()
+        to_update.append(blob)
+    print(f"Found {len(to_update)} orphan attachments to mark for deletion.")
+
+    if DRY_RUN:
+        return
+
+    for chunk in itertools.batched(to_update, BATCH_SIZE):
+        with storage_client.batch():
+            for blob in chunk:
+                print(
+                    f"Marking orphan attachment gs://{STORAGE_BUCKET_NAME}/{blob.name} for deletion"
+                )
+                blob.custom_time = datetime.now(timezone.utc)
+                blob.patch()

--- a/cronjobs/tests/commands/test_expire_orphan_attachments.py
+++ b/cronjobs/tests/commands/test_expire_orphan_attachments.py
@@ -35,7 +35,7 @@ def test_expire_orphan_attachments(mock_fetch_all_changesets, mock_storage_clien
                 {
                     "id": "record1",
                     "last_modified": 1672531200000,
-                    "attachment": {"location": "folder1/att.bin"},
+                    "attachment": {"location": "folder1/att.bin", "size": 12345},
                 }
             ]
         },
@@ -44,7 +44,7 @@ def test_expire_orphan_attachments(mock_fetch_all_changesets, mock_storage_clien
                 {
                     "id": "record1",
                     "last_modified": 1672531200000,
-                    "attachment": {"location": "folder2/file.txt"},
+                    "attachment": {"location": "folder2/file.txt", "size": 12345},
                 }
             ]
         },
@@ -53,7 +53,7 @@ def test_expire_orphan_attachments(mock_fetch_all_changesets, mock_storage_clien
                 {
                     "id": "record1",
                     "last_modified": 1672531200000,
-                    "attachment": {"location": "folder2/img.png"},
+                    "attachment": {"location": "folder2/img.png", "size": 12345},
                 }
             ]
         },


### PR DESCRIPTION
Last run didn't do anything:

<img width="1160" height="265" alt="Screenshot 2025-11-12 at 10 18 26" src="https://github.com/user-attachments/assets/ef72d7db-8236-42c1-a527-6de45ae0e2ae" />


Running manually failed:
```
    return self._do_request(
           ^^^^^^^^^^^^^^^^^
  File "/Users/mathieu/Code/Mozilla/remote-settings/.venv/lib/python3.12/site-packages/google/cloud/storage/batch.py", line 213, in _do_request
    raise ValueError(
ValueError: Too many deferred requests (max 1000)
```