### PR TITLE
git-export: Delete attachments once every 2 days by default

### DIFF
--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -74,8 +74,8 @@ MIN_TAGS_PER_COLLECTION_COUNT = config(
 # This avoids running this potentially expensive operation on every cronjob run.
 # And to avoid duplicating the cronjob definition twice just to set this env var.
 _now = datetime.datetime.now(datetime.timezone.utc)
-_IS_EVEN_DAY = _now.weekday() % 2 == 0
-_SHOULD_DELETE_UNREACHABLE = _IS_EVEN_DAY and _now.hour == 12 and _now.minute > 0 and _now.minute < 15
+_IS_EVEN_DAY = _now.day % 2 == 0
+_SHOULD_DELETE_UNREACHABLE = _IS_EVEN_DAY and _now.hour == 12 and 0 < _now.minute < 15
 
 DELETE_UNREACHABLE_ATTACHMENTS = config(
     "DELETE_UNREACHABLE_ATTACHMENTS", default=_SHOULD_DELETE_UNREACHABLE, cast=bool


### PR DESCRIPTION
Duplicating the git-export cronjob definition is a PIT*   (duplicating volumes, env vars, secrets, ...). Just to set this flag. Plus having 2 cronjobs can run concurrent operations, not great.

This would be an alternative approach. Not the most elegant, but I think it would do it since we run the cronjob every 10min.

Thoughts?