### PR TITLE
Fix RMST-257: do not expect local bucket branches

### DIFF
--- a/git-reader/app.py
+++ b/git-reader/app.py
@@ -221,18 +221,9 @@ class GitService:
         Check that the repository has the expected branches and tags.
         """
         branches = {branch_name for branch_name in self.repo.branches.local}
-        bucket_branches = {
-            branch_name
-            for branch_name in branches
-            if branch_name.startswith(f"{GIT_REF_PREFIX}buckets/")
-        }
         if f"{GIT_REF_PREFIX}common" not in branches:
             raise RuntimeError(
                 f"Missing '{GIT_REF_PREFIX}common' branch in repository. Found: {branches}"
-            )
-        if not bucket_branches:
-            raise RuntimeError(
-                f"Missing '{GIT_REF_PREFIX}buckets/*' branches in repository. Found: {branches}"
             )
 
         # Check that the repository has timestamps/* tags.

--- a/git-reader/tests/test_api.py
+++ b/git-reader/tests/test_api.py
@@ -249,7 +249,10 @@ def test_heartbeat_failing(api_client, temp_dir, monkeypatch):
         shutil.copytree(temp_dir, td, dirs_exist_ok=True)
 
         repo = pygit2.init_repository(td)
-        repo.branches.delete("v1/buckets/main")
+
+        for tag in repo.references:
+            if tag.startswith("refs/tags/v1/timestamps/"):
+                repo.references.delete(tag)
 
         monkeypatch.setenv("GIT_REPO_PATH", td)
 


### PR DESCRIPTION

https://mozilla-hub.atlassian.net/browse/RMST-257

In short: bucket branches are not used.
We can still expect to find in the remote repository, but it's not entirely necessary.

```
$ poetry run python
Python 3.12.10 (main, Apr  8 2025, 11:35:47) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pygit2
>>> repo = pygit2.Repository("/Users/mathieu/Code/remote-settings-data")
>>> print(list(repo.branches.local))
['v1/common']
>>> print(list(repo.branches.remote))
['origin/HEAD', 'origin/v1/buckets/blocklists', 'origin/v1/buckets/blocklists-preview', 'origin/v1/buckets/main', 'origin/v1/buckets/main-preview', 'origin/v1/buckets/security-state', 'origin/v1/buckets/security-state-preview', 'origin/v1/common']
>>> refobj = repo.lookup_reference(f"refs/heads/v1/buckets/security-state-preview")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyError: 'refs/heads/v1/buckets/security-state-preview'
```

In the git reader code we use tags only:
```
>>> refobj = repo.lookup_reference(f"refs/tags/v1/timestamps/blocklists/addons-bloomfilters/1762821380485")
>>> tag = repo[refobj.target]
>>> commit = tag.peel(pygit2.GIT_OBJECT_COMMIT)
>>> folder = repo[commit.tree[0].id]
>>> for e in folder:
...    print(e)
...
<pygit2.Object{blob:ecf59eae511cee61d4403b3c2c42661f2ba59980}>
<pygit2.Object{blob:573aad539a5a08e3da30652514c21c95339c9ffe}>
<pygit2.Object{blob:43a4d57688f37e4be83c81d0083c1ceab7902e98}>
...
```