### PR TITLE
Force full `git-export` once a day

### DIFF
--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -54,7 +54,6 @@ GITHUB_APP_PRIVATE_KEY_PATH = config("GITHUB_APP_PRIVATE_KEY_PATH", default=None
 
 # Internal parameters
 WORK_DIR = config("WORK_DIR", default="/tmp/git-export.git")
-FORCE = config("FORCE", default=False, cast=bool)
 MAX_PARALLEL_REQUESTS = config("MAX_PARALLEL_REQUESTS", default=10, cast=int)
 LOG_LEVEL = config("LOG_LEVEL", default="INFO").upper()
 GIT_SSH_USERNAME = config("GIT_SSH_USERNAME", default="git")
@@ -80,6 +79,12 @@ _SHOULD_DELETE_UNREACHABLE = _IS_EVEN_DAY and _now.hour == 12 and 0 < _now.minut
 DELETE_UNREACHABLE_ATTACHMENTS = config(
     "DELETE_UNREACHABLE_ATTACHMENTS", default=_SHOULD_DELETE_UNREACHABLE, cast=bool
 )
+
+# By default, we only synchronize if there are data changes.
+# But once a day, we run a full sync in order to synchronize collections whose data
+# didn't change but whose metadata did (e.g., signature refreshed, new certs, etc.).
+_SHOULD_FORCE = _now.hour == 0 and 0 < _now.minute < 15
+FORCE = config("FORCE", default=_SHOULD_FORCE, cast=bool)
 
 # Constants
 GIT_REF_PREFIX = "v1/"

--- a/cronjobs/tests/commands/test_git_export.py
+++ b/cronjobs/tests/commands/test_git_export.py
@@ -15,6 +15,7 @@ def configs(monkeypatch, tmp_path):
     monkeypatch.setenv("WORK_DIR", str(tmp_path / "workdir"))
     monkeypatch.setenv("SERVER", "http://testserver:9999/v1")
     monkeypatch.setenv("REPO_NAME", "remote-settings-data-stage")
+    monkeypatch.setenv("FORCE", "false")
     # Fake SSH keys
     ssh_privkey = tmp_path / "id_ed25519"
     ssh_pubkey = tmp_path / "id_ed25519.pub"


### PR DESCRIPTION
Currently, the `git-export` job only looks at records timestamps.

But these timestamps do not change when signatures are refreshed. Leading to outdated metadata in the git repo.

Note: 
* this approach is valid if we leave the `server_compare` as it is (ie. without https://github.com/mozilla-services/telescope/pull/1661) and if we add a check to validate the certificates expiration or the signatures of the data instead.
* alternatively we can also set `FORCE=true` always, and rely on git features to only commit what has changed since last run. It just obliges the script to redownload all changesets on each run 