### PR TITLE
Ref #1106: Do not bother deleting unreferenced commits if not tag was removed

### DIFF
--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -144,7 +144,8 @@ def git_export(event, context):
         # We do this to keep a reasonable number of objects, and most importantly
         # to delete LFS files from remote storage (Github keeps LFS files as long as
         # there is a reference to them in the git history).
-        delete_unreferenced_commits(repo)
+        if len(deleted_tags) > 0:
+            delete_unreferenced_commits(repo)
 
         print(f"{len(changed_attachments)} attachments to upload.")
         github_lfs_batch_upload_many(


### PR DESCRIPTION
Ref #1106

This allowed me to run the job with `FORCE=true` locally.

Once ran successfully with FORCE, then the code was not failing anymore and browsing on Github was fine.
See https://github.com/mozilla/remote-settings-data-dev

Which indicates that the code that trims old tags and old commits is not behaving nicely. And using force=true recreates everything as expected
