### PR TITLE
Adjust v1 reader to make quotes in quoted timestamps optional

### DIFF
--- a/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
@@ -292,7 +292,7 @@ class QuotedTimestamp(colander.SchemaNode):
 
     schema_type = colander.String
     error_message = "The value should be integer, optionally between double quotes."
-    validator = colander.Regex('^"?([0-9]+?)"?(?!\n)$', msg=error_message)
+    validator = colander.Regex('^"([0-9]+?)"(?!\n)$|^([0-9]+?)(?!\n)$', msg=error_message)
 
     def deserialize(self, cstruct=colander.null):
         param = super(QuotedTimestamp, self).deserialize(cstruct)

--- a/kinto-remote-settings/tests/changes/test_changeset.py
+++ b/kinto-remote-settings/tests/changes/test_changeset.py
@@ -111,7 +111,7 @@ class ChangesetViewTest(BaseWebTest, unittest.TestCase):
             self.changeset_uri + "&_since=42", headers=self.headers, status=200
         )
         self.app.get(
-            self.changeset_uri + "&_since=42%22", headers=self.headers, status=200
+            self.changeset_uri + "&_since=42%22", headers=self.headers, status=400
         )
         self.app.get(
             self.changeset_uri + "&_since=%2242%22", headers=self.headers, status=200


### PR DESCRIPTION
This makes quotes in _expected timestamp values optional.
This makes the v1 reader endpoints forward compatible with what the v2 endpoints are expecting.
See #1104 