### PR TITLE
Pushing dev git-reader images to enterprise GAR per their request

### DIFF
--- a/.github/workflows/publish-ent.yaml
+++ b/.github/workflows/publish-ent.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types:
       - released
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
On sync meeting today, enterprise team told me we can get dev images pushed up and they'll sync these to their dev environment automatically for early testing.

[RMST-374](https://mozilla-hub.atlassian.net/browse/RMST-374)