### PR TITLE
RMST-373 - Returning welcome and broadcasts responses when git folder is empty

### DIFF
--- a/git-reader/app.py
+++ b/git-reader/app.py
@@ -81,7 +81,9 @@ METRICS = {
         buckets=[0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, float("inf")],
     ),
 }
-NO_GIT_ERROR = "Unable to load state from git. Has the update job completed?"
+NO_GIT_ERROR = (
+    "Unable to load state from `GIT_REPO_PATH`. Has the `gitupdate` job completed?"
+)
 
 # Augment the default mimetypes with our own.
 mimetypes.init(files=[HERE / "mimetypes.txt"])
@@ -162,7 +164,7 @@ def get_settings() -> Settings:
 def get_last_modified(settings: Settings = Depends(get_settings)) -> int | float:
     try:
         return os.path.getmtime(settings.git_repo_path)
-    except Exception:
+    except OSError:
         return -1
 
 
@@ -217,11 +219,6 @@ class HelloResponse(BaseModel):
 class BroadcastsResponse(BaseModel):
     broadcasts: dict[str, str] = Field(description="Broadcasts")
     code: int = Field(description="HTTP status code")
-    detail: str | None = Field(
-        None,
-        description="Error message detailing the potential problem",
-        exclude_if=lambda v: v is None,
-    )
 
 
 class ChangesetResponse(BaseModel):
@@ -465,9 +462,8 @@ class GitService:
         except Exception as e:
             logger.error(e)
             return {
-                "broadcasts": {"remote-settings/monitor_changes": '"-1"'},
-                "code": 503,
-                "detail": NO_GIT_ERROR,
+                "broadcasts": {},
+                "code": 200,
             }
 
     def get_cert_chain(self, pem: str) -> str:

--- a/git-reader/app.py
+++ b/git-reader/app.py
@@ -81,6 +81,7 @@ METRICS = {
         buckets=[0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, float("inf")],
     ),
 }
+NO_GIT_ERROR = "Unable to load state from git. Has the update job completed?"
 
 # Augment the default mimetypes with our own.
 mimetypes.init(files=[HERE / "mimetypes.txt"])
@@ -158,12 +159,23 @@ def get_settings() -> Settings:
     return settings
 
 
+def get_last_modified(settings: Settings = Depends(get_settings)) -> int | float:
+    try:
+        return os.path.getmtime(settings.git_repo_path)
+    except Exception:
+        return -1
+
+
 @lru_cache(maxsize=1)
-def get_repo(settings: Settings = Depends(get_settings)) -> pygit2.Repository:
+def get_repo(
+    settings: Settings = Depends(get_settings),
+    cache_bust: int = Depends(get_last_modified),
+) -> pygit2.Repository:
     if not settings.git_repo_path:
         raise RuntimeError("GIT_REPO_PATH is not set")
     if not os.path.exists(settings.git_repo_path):
-        raise RuntimeError(f"GIT_REPO_PATH does not exist: {settings.git_repo_path}")
+        logger.error(f"GIT_REPO_PATH does not exist: {settings.git_repo_path}")
+        return pygit2.Repository()
     try:
         logger.info("Opening git repo at: %s", settings.git_repo_path)
         repo = pygit2.Repository(settings.git_repo_path)
@@ -205,6 +217,11 @@ class HelloResponse(BaseModel):
 class BroadcastsResponse(BaseModel):
     broadcasts: dict[str, str] = Field(description="Broadcasts")
     code: int = Field(description="HTTP status code")
+    detail: str | None = Field(
+        None,
+        description="Error message detailing the potential problem",
+        exclude_if=lambda v: v is None,
+    )
 
 
 class ChangesetResponse(BaseModel):
@@ -441,9 +458,17 @@ class GitService:
         """
         Get the broadcasts from the common branch.
         """
-        bcontent = self._get_file_content("broadcasts.json")
-        content = json.loads(bcontent.decode("utf-8"))
-        return content
+        try:
+            bcontent = self._get_file_content("broadcasts.json")
+            content = json.loads(bcontent.decode("utf-8"))
+            return content
+        except Exception as e:
+            logger.error(e)
+            return {
+                "broadcasts": {"remote-settings/monitor_changes": '"-1"'},
+                "code": 503,
+                "detail": NO_GIT_ERROR,
+            }
 
     def get_cert_chain(self, pem: str) -> str:
         """
@@ -600,6 +625,12 @@ def hello(
     settings: Settings = Depends(get_settings),
     git: GitService = Depends(GitService.dep),
 ) -> dict:
+    if git.repo.workdir is None:
+        raise HTTPException(
+            status_code=503,
+            detail=NO_GIT_ERROR,
+        )
+
     # Determine attachments base URL
     attachments_base_url = settings.attachments_base_url
     if attachments_base_url is None:

--- a/git-reader/tests/test_api.py
+++ b/git-reader/tests/test_api.py
@@ -6,7 +6,12 @@ import tempfile
 
 import pygit2
 import pytest
-from app import NO_GIT_ERROR, get_repo, read_json_mozlz4, write_json_mozlz4
+from app import (
+    NO_GIT_ERROR,
+    get_repo,
+    read_json_mozlz4,
+    write_json_mozlz4,
+)
 from fastapi.testclient import TestClient
 from pygit2.enums import ObjectType
 
@@ -372,8 +377,7 @@ def test_broadcast_view_git_error(app, api_client):
 
     assert resp.status_code == 200
     data = resp.json()
-    assert data["broadcasts"]["remote-settings/monitor_changes"] == '"-1"'
-    assert data["detail"]
+    assert data["broadcasts"] == {}
 
 
 def test_monitor_changes_view(api_client):
@@ -632,3 +636,16 @@ def test_metrics_traces_durations(api_client):
         'remotesettings_repository_read_latency_seconds_bucket{le="0.001",operation="get_file_content"}'
         in metrics_text
     )
+
+
+def test_repo_caching(temp_dir, app, api_client):
+    resp = api_client.get("/v2/")
+    assert resp.status_code == 200
+    os.rename(temp_dir, f"{temp_dir}-bak")
+
+    resp = api_client.get("/v2/")
+    assert resp.status_code == 503
+    os.rename(f"{temp_dir}-bak", temp_dir)
+
+    resp = api_client.get("/v2/")
+    assert resp.status_code == 200

--- a/git-reader/tests/test_api.py
+++ b/git-reader/tests/test_api.py
@@ -6,7 +6,7 @@ import tempfile
 
 import pygit2
 import pytest
-from app import read_json_mozlz4, write_json_mozlz4
+from app import NO_GIT_ERROR, get_repo, read_json_mozlz4, write_json_mozlz4
 from fastapi.testclient import TestClient
 from pygit2.enums import ObjectType
 
@@ -49,6 +49,10 @@ def upsert_blobs(repo, items, base_tree=None):
         rec(root, [p for p in path.strip("/").split("/") if p], oid)
 
     return root.write()
+
+
+def empty_get_repo():
+    return pygit2.Repository()
 
 
 @pytest.fixture(scope="module")
@@ -244,6 +248,7 @@ def get_settings_override(temp_dir, monkeypatch):
 def app(get_settings_override, monkeypatch):
     from app import app, get_settings
 
+    app.dependency_overrides = {}
     app.dependency_overrides[get_settings] = get_settings_override
     return app
 
@@ -344,12 +349,31 @@ def test_hello_view(api_client):
     assert resp.headers["cache-control"] == "max-age=3600"
 
 
+def test_hello_view_git_error(app, api_client):
+    app.dependency_overrides[get_repo] = empty_get_repo
+    resp = api_client.get("/v2/")
+
+    assert resp.status_code == 503
+    data = resp.json()
+    assert data["detail"] == NO_GIT_ERROR
+
+
 def test_broadcast_view(api_client):
     resp = api_client.get("/v2/__broadcasts__")
     assert resp.status_code == 200
     data = resp.json()
     assert "remote-settings/monitor_changes" in data["broadcasts"]
     assert resp.headers["cache-control"] == "max-age=60"
+
+
+def test_broadcast_view_git_error(app, api_client):
+    app.dependency_overrides[get_repo] = empty_get_repo
+    resp = api_client.get("/v2/__broadcasts__")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["broadcasts"]["remote-settings/monitor_changes"] == '"-1"'
+    assert data["detail"]
 
 
 def test_monitor_changes_view(api_client):


### PR DESCRIPTION
[RMST-373](https://mozilla-hub.atlassian.net/browse/RMST-373)
When git-reader's data has not been fully initialized, we don't return great responses on the root or broadcast endpoints. This aims to improve that.

- Broadcast endpoint now returns an empty object, rather than just 500.
    - Note: actual http response code is still 200 to not break existing logic
- Root response now returns a 503 with an error message

Unsure if we can improve anything beyond this without the git state.