### PR TITLE
git-export: RMST-355: Fix tags and commits truncation bugs

### DIFF
--- a/cronjobs/src/commands/_git_export_git_tools.py
+++ b/cronjobs/src/commands/_git_export_git_tools.py
@@ -287,13 +287,13 @@ def delete_old_tags(
         group_by_collection.setdefault(collection, []).append((ref_name, timestamp))
 
     # For each collection, we find all the tags that are older than
-    # theshold. We keep at least `min_tags_per_collection` after that threshold
-    # to make sure let client catch up with synchronization.
-    # This logics helps us cover the situation described in mozilla/remote-settings#1109
+    # threshold. We keep the most recent `min_tags_per_collection` old tags
+    # to make sure clients can catch up with synchronization.
+    # This logic helps us cover the situation described in mozilla/remote-settings#1109
     # (several updates in a short period of time after a long inactivity).
     for collection, tags in group_by_collection.items():
         kept_count = 0
-        for ref_name, timestamp in tags:
+        for ref_name, timestamp in reversed(tags):
             age_days = (now_ts - timestamp) / (60 * 60 * 24)
             if age_days < max_age_days:
                 continue

--- a/cronjobs/src/commands/_git_export_git_tools.py
+++ b/cronjobs/src/commands/_git_export_git_tools.py
@@ -350,15 +350,17 @@ def truncate_branch(
     chain_commits: list[pygit2.Commit] = []
     walker = repo.walk(tip_oid, SortMode.TOPOLOGICAL | SortMode.TIME)
     to_delete_count = 0
+    past_tagged_region = False
     for commit in walker:
-        # Stop when we reach an untagged commit
         if commit.id not in commits_to_refs:
             assert len(chain_commits) > 0, (
                 f"No tagged commit found in branch {branch}, cannot truncate"
             )
+            # Count all untagged commits below the oldest tagged commit.
+            past_tagged_region = True
             to_delete_count += 1
-            break
-        chain_commits.append(commit)
+        elif not past_tagged_region:
+            chain_commits.append(commit)
 
     assert chain_commits, f"No tagged commit found in branch {branch}"
 

--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -157,7 +157,7 @@ def git_export():
         if len(deleted_tags) > 0:
             truncate_branch(
                 repo,
-                f"{GIT_REF_PREFIX}/{COMMON_BRANCH}",
+                f"{GIT_REF_PREFIX}{COMMON_BRANCH}",
                 tags_deletion_threshold=TAGS_DELETION_THRESHOLD,
             )
 

--- a/cronjobs/tests/commands/test_git_export_git_tools.py
+++ b/cronjobs/tests/commands/test_git_export_git_tools.py
@@ -189,7 +189,8 @@ def test_delete_old_tags(tmp_repo):
     assert len(deleted) == 3
 
     assert f"refs/tags/{recent_tag}" in repo.references
-    for old_tag in tags[3:]:
+    # Keep the 2 most-recent old tags (closest to the threshold boundary).
+    for old_tag in tags[:2]:
         assert f"refs/tags/{old_tag}" in repo.references
 
 


### PR DESCRIPTION
RMST-355

This part hasn't been tested extensively, and has bugs:

- `f"{GIT_REF_PREFIX}{COMMON_BRANCH}"` had an extra slash. `truncate_branch()` computes `branch_ref_name = "refs/heads/v1//common"` which won't match any real reference and will raise a `KeyError`., meaning that truncation has never fired in production.
- The tag deletion walker breaks on the first untagged commit, so `to_delete_count` is always 0 (clean) or 1 (any
  untagged commits exist). The threshold check `to_delete_count < X` is therefore always True. The loop needs to count all untagged commits instead of stopping at one
- The test `test_truncate_branch_if_more_untagged_than_threshold` deletes 2 tags (→ 2 untagged commits) and
  uses `threshold=3`. The test passes only because `to_delete_count=1 < 3`, not because it actually counted 2
  untagged commits. The test itself is asserting accidentally-correct behavior.
- In tags deletion, tags are processed in ascending sort order (oldest first). The loop skips newer-than-threshold tags, then `kept_count` preserves the first `min_tags_per_collection` old tags encountered, which are the oldest
  ones, and not the newest old tags. The fix: iterate reversed(tags) so kept_count captures the newest min_tags_per_collection old tags before deleting the older ones.