### PR TITLE
Add project_name, project_version, url to Slack notification context

### DIFF
--- a/browser-tests/plugins/test_slack.py
+++ b/browser-tests/plugins/test_slack.py
@@ -18,7 +18,7 @@ def test_slack_plugin(
                         {
                             "event": "kinto_remote_settings.signer.events.ReviewRequested",
                             "channel": "#reviews",
-                            "template": "{user_id} requested review for {changes_count} changes ({comment}) on {bucket_id}/{collection_id}.",
+                            "template": "{user_id} requested review for {changes_count} changes ({comment}) on {bucket_id}/{collection_id} on {settings[project_name]}.",
                         }
                     ]
                 }
@@ -51,4 +51,5 @@ def test_slack_plugin(
     assert payload["channel"] == "#reviews"
     assert "integration-tests" in payload["text"]
     assert "looks good" in payload["text"]
+    assert "Remote Settings LOCAL" in payload["text"]  # see config/local.ini
     assert re.search(r"\d+ changes", payload["text"])

--- a/kinto-slack/src/kinto_slack/__init__.py
+++ b/kinto-slack/src/kinto_slack/__init__.py
@@ -82,6 +82,11 @@ def build_notification(event):
         event=qualname(event),
         **event.payload,
     )
+    context["settings"] = {
+        k: v
+        for k, v in event.request.registry.settings.items()
+        if k in ("project_name", "url", "project_version")
+    }
     context.setdefault("record_id", "{record_id}")
     context.setdefault("collection_id", "{collection_id}")
 


### PR DESCRIPTION
This would allow to define the notification as ``✨ collection {collection_id} was created on {settings[project_name]}`` instead of having to duplicate the notification definition on each environment.

See also https://github.com/Kinto/kinto-emailer/pull/510