### PR TITLE
cronjob: read from syndicated dataset

### DIFF
--- a/cronjobs/src/commands/consumption_movers.py
+++ b/cronjobs/src/commands/consumption_movers.py
@@ -22,7 +22,7 @@ WITH daily_consumption AS (
         DATE_TRUNC(timestamp, DAY) AS day,
         collection_id,
         SUM(size) AS size
-    FROM `mozdata.remote_settings_logs_aggregates.prod_logs_aggregates`
+    FROM `moz-fx-remote-settings-prod.remote_settings_logs_aggregates.prod_logs_aggregates`
     WHERE timestamp >= TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY), INTERVAL {interval_days_start} DAY)
       AND timestamp <  TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY), INTERVAL {interval_days_end} DAY)
       AND collection_id IS NOT NULL


### PR DESCRIPTION
Reading from `mozdata` requires some permissions changes in bigquery-etl. 
The syndicated dataset is in the same project and should be easier to read from.

See https://github.com/mozilla/webservices-infra/pull/10933