### PR TITLE
Ref RMST-388: show absolute bandwidth value

### DIFF
--- a/cronjobs/src/commands/consumption_movers.py
+++ b/cronjobs/src/commands/consumption_movers.py
@@ -90,14 +90,14 @@ Period: {start_day.strftime("%b %-d")} → {end_day.strftime("%b %-d")}"""
     ):
         message += f"""\n
 *Top increases* (Compared against previous {PREVIOUS_PERIOD_DAYS}-day daily average)
-{"\n".join(f"- `{m['collection_id']}`: {m['pct_change']:+.1f}% " for m in top_increase)}"""
+{"\n".join(f"- `{m['collection_id']}`: +{m['delta'] / 1e12:.1f}TB ({m['pct_change']:+.1f}%) " for m in top_increase)}"""
 
     if top_decrease := heapq.nsmallest(
         TOP_N, [m for m in movers if m["pct_change"] < 0], key=lambda m: m["delta"]
     ):
         message += f"""\n
 *Top decreases*
-{"\n".join(f"- `{m['collection_id']}`: {m['pct_change']:+.1f}% " for m in top_decrease)}"""
+{"\n".join(f"- `{m['collection_id']}`: {m['delta'] / 1e12:.1f}TB ({m['pct_change']:+.1f}%) " for m in top_decrease)}"""
 
     if not SLACK_WEBHOOK_URL:
         print("SLACK_WEBHOOK_URL is not set; message was not sent")


### PR DESCRIPTION

<img width="520" height="358" alt="Screenshot 2026-05-13 at 16 36 56" src="https://github.com/user-attachments/assets/16a170c3-62c2-42b2-9fa9-b25485a3d961" />


```
➜  cronjobs git:(rmst-388-sort-consumers) ✗ uv run python src/main.py consumption_movers
SENTRY_DSN not set; Sentry SDK not initialized.
SLACK_WEBHOOK_URL is not set; message was not sent
Slack message:
*Bandwidth Consumption*
Period: May 5 → May 12

*Top increases* (Compared against previous 90-day daily average)
- `translations-models`: +17.5TB (+271.3%)
- `crash-reports-ondemand`: +14.3TB (+453.7%)
- `startup`: +1.4TB (+15.9%)
- `nimbus-desktop-experiments`: +0.6TB (+20.0%)
- `search-categorization`: +0.3TB (+27.0%)

*Top decreases*
- `quicksuggest-amp`: -200.3TB (-90.4%)
- `cert-revocations`: -67.4TB (-30.8%)
- `intermediates`: -13.8TB (-40.8%)
- `newtab-wallpapers-v2`: -5.4TB (-54.2%)
- `addons-bloomfilters`: -5.3TB (-32.4%)
```