### PR TITLE
Skip changes detection outside pull-requests

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,6 +36,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: filter
+        if: github.event_name == 'pull_request'
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Should fix this:

```
Run files=$(git diff --name-only "$BASE" "$HEAD")
    files=$(git diff --name-only "$BASE" "$HEAD")
    echo "Changed files:"
    echo "$files"
    check() {
      if echo "$files" | grep -qE "$2"; then
        echo "$1=true" >> "$GITHUB_OUTPUT"
      else
        echo "$1=false" >> "$GITHUB_OUTPUT"
      fi
    }
    check cronjobs       '^.github/workflows/|^cronjobs/'
    check browser_tests  '^.github/workflows/|^browser-tests/'
    check git_reader     '^.github/workflows/|^git-reader/'
    shell: /usr/bin/bash -e {0}
    env:
      BUILDX_NO_DEFAULT_ATTESTATIONS: 1
      GAR_LOCATION: us
      GAR_REPOSITORY: remote-settings-prod
      GCP_PROJECT_ID: moz-fx-remote-settings-prod
      BASE:
      HEAD:
  fatal: ambiguous argument '': unknown revision or path not in the working tree.
  Use '--' to separate paths from revisions, like this:
  'git <command> [<revision>...] -- [<file>...]'
  Error: Process completed with exit code 128.

```