### PR TITLE
Install `curl` in production container, not only local

### DIFF
--- a/RemoteSettings.Dockerfile
+++ b/RemoteSettings.Dockerfile
@@ -65,6 +65,7 @@ ENV KINTO_INI=config/local.ini \
 
 COPY /bin/update_and_install_system_packages.sh /opt
 RUN /opt/update_and_install_system_packages.sh \
+    curl \
     # Needed for psycopg2
     libpq-dev
 
@@ -100,11 +101,6 @@ FROM production AS local
 # Serve attachments at /attachments
 ENV GRANIAN_STATIC_PATH_ROUTE=/attachments
 ENV GRANIAN_STATIC_PATH_MOUNT=/tmp/attachments
-
-# Install curl for readiness test in docker compose
-USER root
-RUN /opt/update_and_install_system_packages.sh curl
-USER app
 
 # create directories for volume mounts used in browser tests / local development
 RUN mkdir -p -m 777 /app/mail && mkdir -p -m 777 /app/slack && mkdir -p -m 777 /tmp/attachments


### PR DESCRIPTION
`curl` was installed in the local container, but not production. Preventing other teams pulling from dockerhub to use the curl readiness command