### PR TITLE
Remove redundant python setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - uses: actions/setup-python@v6
-        with:
           python-version: "3.14.5"
       - name: Install dependencies
         run: make install
@@ -37,8 +35,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - uses: actions/setup-python@v6
-        with:
           python-version: "3.14.5"
       - name: Check documentation build
         run: make docs
@@ -69,8 +65,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - uses: actions/setup-python@v6
-        with:
           python-version: "3.14.5"
       - name: Install dependencies
         run: make install


### PR DESCRIPTION
Already part of `astral-sh/setup-uv`