### PR TITLE
Use GHA-based caching instead of local

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,21 +80,8 @@ jobs:
   cronjobs-test:
     needs: run_test
     runs-on: ubuntu-latest
-    env:
-      DOCKER_CACHE: /tmp/docker-cache
     steps:
       - uses: actions/checkout@v6
-      - name: Compute cache key
-        # Create hash of hashes of checked in files not in Dockerignore
-        run: echo "CACHE_KEY=$(git ls-tree --full-tree -r HEAD | grep -v -f .dockerignore | awk '{print $3}' | git hash-object --stdin)" >> "$GITHUB_ENV"
-
-      - uses: actions/cache@v5
-        with:
-          path: ${{ env.DOCKER_CACHE}}
-          key: docker-build-${{ hashFiles('cronjobs/Dockerfile') }}-${{ env.CACHE_KEY }}
-          restore-keys: |
-            docker-build-${{ hashFiles('cronjobs/Dockerfile') }}-${{ env.CACHE_KEY }}
-            docker-build-${{ hashFiles('cronjobs/Dockerfile') }}-
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -104,8 +91,8 @@ jobs:
       - name: Build cronjobs container
         uses: docker/build-push-action@v7
         with:
-          cache-from: type=local,src=${{ env.DOCKER_CACHE}}/cronjobs
-          cache-to: type=local,dest=${{ env.DOCKER_CACHE}}/cronjobs,mode=max
+          cache-from: type=gha,scope=cronjobs-ci
+          cache-to: type=gha,mode=max,scope=cronjobs-ci
           load: true
           file: cronjobs/Dockerfile
           context: cronjobs/
@@ -119,24 +106,10 @@ jobs:
     needs: run_test
     runs-on: ubuntu-latest
     env:
-      DOCKER_CACHE: /tmp/docker-cache
       CONFIG_MOUNT: ""
       SRC_MOUNT: ""
     steps:
       - uses: actions/checkout@v6
-
-      - name: Compute cache key
-        # Create hash of hashes of checked in files not in Dockerignore
-        run: echo "CACHE_KEY=$(git ls-tree --full-tree -r HEAD | grep -v -f .dockerignore | awk '{print $3}' | git hash-object --stdin)" >> "$GITHUB_ENV"
-
-      - uses: actions/cache@v5
-        with:
-          path: ${{ env.DOCKER_CACHE}}
-          key: docker-build-${{ hashFiles('RemoteSettings.Dockerfile', 'browser-tests/Dockerfile') }}-${{ env.CACHE_KEY }}
-          restore-keys: |
-            docker-build-${{ hashFiles('RemoteSettings.Dockerfile', 'browser-tests/Dockerfile') }}-${{ env.CACHE_KEY }}
-            docker-build-${{ hashFiles('RemoteSettings.Dockerfile', 'browser-tests/Dockerfile') }}-
-            docker-build-
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -146,8 +119,8 @@ jobs:
       - name: Build web container
         uses: docker/build-push-action@v7
         with:
-          cache-from: type=local,src=${{ env.DOCKER_CACHE}}/web
-          cache-to: type=local,dest=${{ env.DOCKER_CACHE}}/web,mode=max
+          cache-from: type=gha,scope=web-ci
+          cache-to: type=gha,mode=max,scope=web-ci
           file: RemoteSettings.Dockerfile
           context: .
           tags: remotesettings/local  # Like with docker compose build web
@@ -155,8 +128,8 @@ jobs:
       - name: Build test container
         uses: docker/build-push-action@v7
         with:
-          cache-from: type=local,src=${{ env.DOCKER_CACHE}}/tests
-          cache-to: type=local,dest=${{ env.DOCKER_CACHE}}/tests,mode=max
+          cache-from: type=gha,scope=tests-ci
+          cache-to: type=gha,mode=max,scope=tests-ci
           context: browser-tests/
 
       - name: Run browser tests

--- a/.github/workflows/ingestion-job-publish.yaml
+++ b/.github/workflows/ingestion-job-publish.yaml
@@ -101,5 +101,5 @@ jobs:
           context: .
           push: ${{ inputs.publish }}
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha,buildkit=true
-          cache-to: type=gha,mode=max,buildkit=true
+          cache-from: type=gha,scope=ingestion-job
+          cache-to: type=gha,mode=max,scope=ingestion-job


### PR DESCRIPTION
Switch the Docker cache from `type=local` to `type=gha,scope=…` like we do in publish workflow