### PR TITLE
Fix #788: do not raise 400 on multiple changes involving attachments

### DIFF
--- a/kinto-remote-settings/src/kinto_remote_settings/signer/utils.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/signer/utils.py
@@ -238,18 +238,14 @@ def notify_resource_event(
     # When kinto-signer copies record from one place to another,
     # it simulates a resource event. Since kinto-attachment
     # prevents from updating attachment fields, it throws an error.
-    # The following flag will disable the kinto-attachment check.
-    # See https://github.com/Kinto/kinto-signer/issues/256
-    # and https://bugzilla.mozilla.org/show_bug.cgi?id=1470812
-    has_changed_attachment = (
-        resource_name == "record"
-        and action == ACTIONS.UPDATE
-        and old is not None
-        and "attachment" in old
-        and old["attachment"] != obj.get("attachment")
-    )
-    if has_changed_attachment:
-        fakerequest._attachment_auto_save = True
+    # Set the flag unconditionally: Kinto's event aggregator keeps
+    # only the first queued event's request when merging events with
+    # the same (resource, parent_id, action) key, so the flag must be
+    # set on every fakerequest in the batch (not just the ones with
+    # an attachment change) to be reliably visible on the merged event.
+    # See https://github.com/mozilla/remote-settings/issues/788
+    # and https://github.com/Kinto/kinto-signer/issues/256.
+    fakerequest._attachment_auto_save = True
 
     fakerequest.notify_resource_event(
         parent_id=parent_id,

--- a/kinto-remote-settings/tests/signer/test_signer_attachments.py
+++ b/kinto-remote-settings/tests/signer/test_signer_attachments.py
@@ -146,3 +146,66 @@ class SignerAttachmentsTest(BaseWebTest, unittest.TestCase):
         attachment_after = record["attachment"]["hash"]
 
         assert attachment_before != attachment_after
+
+    def test_sign_batch_with_mixed_attachment_and_non_attachment_records(self):
+        # Repro for https://github.com/mozilla/remote-settings/issues/788
+        # When a sign batch contains an attachment-change record AND a
+        # non-attachment-change record, Kinto's event aggregator keeps the
+        # request from the FIRST queued event. If that request lacks the
+        # `_attachment_auto_save` flag, kinto-attachment raises 400 on the
+        # batched event because one of the merged impacted_objects has an
+        # attachment that differs.
+        r = self.app.post_json(
+            self.source_collection + "/records",
+            {"data": {"title": "no-attach"}},
+            headers=self.headers,
+        )
+        rec_no_attach = r.json["data"]
+
+        r = self.app.post_json(
+            self.source_collection + "/records",
+            {"data": {"title": "with-attach"}},
+            headers=self.headers,
+        )
+        rec_with_attach = r.json["data"]
+        self.upload_file(
+            uri=self.source_collection
+            + "/records/"
+            + rec_with_attach["id"]
+            + "/attachment",
+            files=[("attachment", "image.jpg", b"--fake--")],
+            headers=self.headers,
+        )
+
+        # Sign once so both records exist in the destination.
+        self.app.patch_json(
+            self.source_collection,
+            {"data": {"status": "to-sign"}},
+            headers=self.headers,
+        )
+
+        # Modify the data of the no-attachment record.
+        self.app.patch_json(
+            self.source_collection + "/records/" + rec_no_attach["id"],
+            {"data": {"title": "no-attach-updated"}},
+            headers=self.headers,
+        )
+        # Replace the attachment of the other record.
+        self.upload_file(
+            uri=self.source_collection
+            + "/records/"
+            + rec_with_attach["id"]
+            + "/attachment",
+            files=[("attachment", "image.jpg", b"--other-fake--")],
+            headers=self.headers,
+        )
+
+        # Second sign: batched record events must not raise 400.
+        self.app.patch_json(
+            self.source_collection,
+            {"data": {"status": "to-sign"}},
+            headers=self.headers,
+            status=200,
+        )
+        r = self.app.get(self.source_collection, headers=self.headers)
+        assert r.json["data"]["status"] == "signed"


### PR DESCRIPTION
Fix #788