### PR TITLE
Add missing perms to CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   run_lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See https://github.com/mozilla/remote-settings/security/code-scanning/43