### PR TITLE
Add subdependencies to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
     development-dependencies:
       dependency-type: "development"
       update-types: ["major", "minor", "patch"]
+    sub-dependencies:
+      dependency-type: "indirect"
+      update-types: ["major", "minor", "patch"]
   open-pull-requests-limit: 99
 - package-ecosystem: docker
   directory: "/"


### PR DESCRIPTION
⚠️ changes of this PR are wrong:

```

Your .github/dependabot.yml contained invalid details

Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/updates/0/groups/sub-dependencies/dependency-type' value "indirect" did not match one of the following values: production, development

Please update the config file to conform with Dependabot's specification.
```

See #1330 