### PR TITLE
RMST-355 - Fixing history purge in git-export

### DIFF
--- a/cronjobs/src/commands/_git_export_git_tools.py
+++ b/cronjobs/src/commands/_git_export_git_tools.py
@@ -273,7 +273,7 @@ def delete_old_tags(
         f"Delete tags older than {max_age_days} days, keeping at least {min_tags_per_collection} per collection."
     )
     deleted_tags = []
-    now_ts = int(time.time())
+    now_ts = int(time.time() * 1000)
 
     timestamp_tags = [
         ref_name

--- a/cronjobs/tests/commands/test_git_export_git_tools.py
+++ b/cronjobs/tests/commands/test_git_export_git_tools.py
@@ -158,10 +158,10 @@ def test_reset_repo_deletes_extra_local_branches_and_tags(tmp_repo, mock_ls_remo
 
 def test_delete_old_tags(tmp_repo):
     repo = tmp_repo
-    now_ts = int(time.time())
+    now_ts = int(time.time() * 1000)
 
     commit = tmp_repo.revparse_single("main")
-    tags = [f"v1/timestamps/common/{now_ts - i * 86400!s}" for i in range(5, 10)]
+    tags = [f"v1/timestamps/common/{now_ts - i * 86400000}" for i in range(5, 10)]
     for old_tag in tags:
         repo.create_tag(
             old_tag,


### PR DESCRIPTION
[RMST-355](https://mozilla-hub.atlassian.net/browse/RMST-355)

The history purge in git-export is not working as expected. We appear to have a mixup of seconds vs milliseconds in the tag timestamps.

Adjusted unit test to confirm it failed when using millisecond tags.
Adjusted code to use millis and verified unit tests pass now.