### PR TITLE
RMST-355 - Fixing git export delete_old_tags logic around tags to keep

### DIFF
--- a/cronjobs/src/commands/_git_export_git_tools.py
+++ b/cronjobs/src/commands/_git_export_git_tools.py
@@ -294,10 +294,8 @@ def delete_old_tags(
     for collection, tags in group_by_collection.items():
         kept_count = 0
         for ref_name, timestamp in reversed(tags):
-            age_days = (now_ts - timestamp) / (60 * 60 * 24)
-            if age_days < max_age_days:
-                continue
-            if kept_count < min_tags_per_collection:
+            age_days = (now_ts - timestamp) / (60 * 60 * 24 * 1000)
+            if age_days < max_age_days or kept_count < min_tags_per_collection:
                 kept_count += 1
                 continue
 

--- a/cronjobs/tests/commands/test_git_export_git_tools.py
+++ b/cronjobs/tests/commands/test_git_export_git_tools.py
@@ -194,41 +194,41 @@ def test_delete_old_tags(tmp_repo):
 
 
 def test_delete_new_and_old_tags(tmp_repo):
-      repo = tmp_repo
-      now_ts = int(time.time() * 1000)
+    repo = tmp_repo
+    now_ts = int(time.time() * 1000)
 
-      commit = tmp_repo.revparse_single("main")
-      tags = [f"v1/timestamps/common/{now_ts - i * 86400000}" for i in range(1, 10)]
-      for old_tag in tags:
-          repo.create_tag(
-              old_tag,
-              commit.id,
-              pygit2.GIT_OBJECT_COMMIT,
-              pygit2.Signature("Tester", "test@example.com"),
-              "An old tag",
-          )
+    commit = tmp_repo.revparse_single("main")
+    tags = [f"v1/timestamps/common/{now_ts - i * 86400000}" for i in range(1, 10)]
+    for tag in tags:
+        repo.create_tag(
+            tag,
+            commit.id,
+            pygit2.GIT_OBJECT_COMMIT,
+            pygit2.Signature("Tester", "test@example.com"),
+            "An old tag",
+        )
 
-      recent_tag = f"v1/timestamps/common/{now_ts}"
-      repo.create_tag(
-          recent_tag,
-          commit.id,
-          pygit2.GIT_OBJECT_COMMIT,
-          pygit2.Signature("Tester", "test@example.com"),
-          "A recent tag",
-      )
+    recent_tag = f"v1/timestamps/common/{now_ts}"
+    repo.create_tag(
+        recent_tag,
+        commit.id,
+        pygit2.GIT_OBJECT_COMMIT,
+        pygit2.Signature("Tester", "test@example.com"),
+        "A recent tag",
+    )
 
-      assert f"refs/tags/{recent_tag}" in repo.references
-      for old_tag in tags:
-          assert f"refs/tags/{old_tag}" in repo.references
+    assert f"refs/tags/{recent_tag}" in repo.references
+    for tag in tags:
+        assert f"refs/tags/{tag}" in repo.references
 
-      deleted = delete_old_tags(repo, max_age_days=5, min_tags_per_collection=2)
+    deleted = delete_old_tags(repo, max_age_days=5, min_tags_per_collection=2)
 
-      # Keep all recent tags, but delete all tags beyond max_age_days
-      assert len(deleted) == 5
-      assert f"refs/tags/{recent_tag}" in repo.references
-      for t in tags[0:4]:
+    # Keep all recent tags, but delete all tags beyond max_age_days
+    assert len(deleted) == 5
+    assert f"refs/tags/{recent_tag}" in repo.references
+    for t in tags[0:4]:
         assert f"refs/tags/{t}" in repo.references
-      for t in tags[4:]:
+    for t in tags[4:]:
         assert f"refs/tags/{t}" not in repo.references
 
 

--- a/cronjobs/tests/commands/test_git_export_git_tools.py
+++ b/cronjobs/tests/commands/test_git_export_git_tools.py
@@ -161,7 +161,7 @@ def test_delete_old_tags(tmp_repo):
     now_ts = int(time.time() * 1000)
 
     commit = tmp_repo.revparse_single("main")
-    tags = [f"v1/timestamps/common/{now_ts - i * 86400000}" for i in range(5, 10)]
+    tags = [f"v1/timestamps/common/{now_ts - i * 86400000}" for i in range(6, 11)]
     for old_tag in tags:
         repo.create_tag(
             old_tag,
@@ -186,12 +186,55 @@ def test_delete_old_tags(tmp_repo):
 
     deleted = delete_old_tags(repo, max_age_days=5, min_tags_per_collection=2)
 
-    assert len(deleted) == 3
+    assert len(deleted) == 4
+
+    # Keep the 2 most-recent old tags (closest to the threshold boundary).
+    assert f"refs/tags/{recent_tag}" in repo.references
+    assert f"refs/tags/{tags[0]}" in repo.references
+
+
+def test_delete_new_and_old_tags(tmp_repo):
+    repo = tmp_repo
+    now_ts = int(time.time() * 1000)
+
+    commit = tmp_repo.revparse_single("main")
+    old_tags = [f"v1/timestamps/common/{now_ts - i * 86400000}" for i in range(6, 11)]
+    for old_tag in old_tags:
+        repo.create_tag(
+            old_tag,
+            commit.id,
+            pygit2.GIT_OBJECT_COMMIT,
+            pygit2.Signature("Tester", "test@example.com"),
+            "An old tag",
+        )
+
+    new_tags = [f"v1/timestamps/common/{now_ts - i * 86400000}" for i in range(1, 5)]
+    for new_tag in new_tags:
+        repo.create_tag(
+            new_tag,
+            commit.id,
+            pygit2.GIT_OBJECT_COMMIT,
+            pygit2.Signature("Tester", "test@example.com"),
+            "A newer tag",
+        )
+    recent_tag = f"v1/timestamps/common/{now_ts}"
+    repo.create_tag(
+        recent_tag,
+        commit.id,
+        pygit2.GIT_OBJECT_COMMIT,
+        pygit2.Signature("Tester", "test@example.com"),
+        "A recent tag",
+    )
 
     assert f"refs/tags/{recent_tag}" in repo.references
-    # Keep the 2 most-recent old tags (closest to the threshold boundary).
-    for old_tag in tags[:2]:
+    for old_tag in old_tags:
         assert f"refs/tags/{old_tag}" in repo.references
+
+    deleted = delete_old_tags(repo, max_age_days=5, min_tags_per_collection=2)
+
+    assert len(deleted) == 5
+
+    assert f"refs/tags/{recent_tag}" in repo.references
 
 
 @pytest.fixture

--- a/cronjobs/tests/commands/test_git_export_git_tools.py
+++ b/cronjobs/tests/commands/test_git_export_git_tools.py
@@ -194,47 +194,42 @@ def test_delete_old_tags(tmp_repo):
 
 
 def test_delete_new_and_old_tags(tmp_repo):
-    repo = tmp_repo
-    now_ts = int(time.time() * 1000)
+      repo = tmp_repo
+      now_ts = int(time.time() * 1000)
 
-    commit = tmp_repo.revparse_single("main")
-    old_tags = [f"v1/timestamps/common/{now_ts - i * 86400000}" for i in range(6, 11)]
-    for old_tag in old_tags:
-        repo.create_tag(
-            old_tag,
-            commit.id,
-            pygit2.GIT_OBJECT_COMMIT,
-            pygit2.Signature("Tester", "test@example.com"),
-            "An old tag",
-        )
+      commit = tmp_repo.revparse_single("main")
+      tags = [f"v1/timestamps/common/{now_ts - i * 86400000}" for i in range(1, 10)]
+      for old_tag in tags:
+          repo.create_tag(
+              old_tag,
+              commit.id,
+              pygit2.GIT_OBJECT_COMMIT,
+              pygit2.Signature("Tester", "test@example.com"),
+              "An old tag",
+          )
 
-    new_tags = [f"v1/timestamps/common/{now_ts - i * 86400000}" for i in range(1, 5)]
-    for new_tag in new_tags:
-        repo.create_tag(
-            new_tag,
-            commit.id,
-            pygit2.GIT_OBJECT_COMMIT,
-            pygit2.Signature("Tester", "test@example.com"),
-            "A newer tag",
-        )
-    recent_tag = f"v1/timestamps/common/{now_ts}"
-    repo.create_tag(
-        recent_tag,
-        commit.id,
-        pygit2.GIT_OBJECT_COMMIT,
-        pygit2.Signature("Tester", "test@example.com"),
-        "A recent tag",
-    )
+      recent_tag = f"v1/timestamps/common/{now_ts}"
+      repo.create_tag(
+          recent_tag,
+          commit.id,
+          pygit2.GIT_OBJECT_COMMIT,
+          pygit2.Signature("Tester", "test@example.com"),
+          "A recent tag",
+      )
 
-    assert f"refs/tags/{recent_tag}" in repo.references
-    for old_tag in old_tags:
-        assert f"refs/tags/{old_tag}" in repo.references
+      assert f"refs/tags/{recent_tag}" in repo.references
+      for old_tag in tags:
+          assert f"refs/tags/{old_tag}" in repo.references
 
-    deleted = delete_old_tags(repo, max_age_days=5, min_tags_per_collection=2)
+      deleted = delete_old_tags(repo, max_age_days=5, min_tags_per_collection=2)
 
-    assert len(deleted) == 5
-
-    assert f"refs/tags/{recent_tag}" in repo.references
+      # Keep all recent tags, but delete all tags beyond max_age_days
+      assert len(deleted) == 5
+      assert f"refs/tags/{recent_tag}" in repo.references
+      for t in tags[0:4]:
+        assert f"refs/tags/{t}" in repo.references
+      for t in tags[4:]:
+        assert f"refs/tags/{t}" not in repo.references
 
 
 @pytest.fixture


### PR DESCRIPTION
Discovered two small bugs on git-export truncation.

1. I had missed a millisecond conversion in age_days check
2. We were not counting recent tags in `kept_count`