### PR TITLE
Add typos check in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,15 +25,8 @@ jobs:
         env:
           ACTIONLINT_VERSION: 1.7.7
           ACTIONLINT_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757  # pragma: allowlist secret
-      - name: Check typos
-        run: |
-          curl --fail -L "https://github.com/crate-ci/typos/releases/download/v${{ env.TYPOS_VERSION }}/typos-v${{ env.TYPOS_VERSION }}-x86_64-unknown-linux-musl.tar.gz" -o typos.tar.gz
-          echo "${{ env.TYPOS_SHA256 }} typos.tar.gz" | sha256sum --check -
-          tar zxvf typos.tar.gz ./typos
-          ./typos
-        env:
-          TYPOS_VERSION: 1.47.0
-          TYPOS_SHA256: 6f8a935cea6c60b060082b862a7e777bfd92d939a4fd4194d8085b086dfe24e4  # pragma: allowlist secret
+      - name: Install typos spellcheck
+        run: cargo install typos-cli
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,15 @@ jobs:
         env:
           ACTIONLINT_VERSION: 1.7.7
           ACTIONLINT_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757  # pragma: allowlist secret
+      - name: Check typos
+        run: |
+          curl --fail -L "https://github.com/crate-ci/typos/releases/download/v${{ env.TYPOS_VERSION }}/typos-v${{ env.TYPOS_VERSION }}-x86_64-unknown-linux-musl.tar.gz" -o typos.tar.gz
+          echo "${{ env.TYPOS_SHA256 }} typos.tar.gz" | sha256sum --check -
+          tar zxvf typos.tar.gz ./typos
+          ./typos
+        env:
+          TYPOS_VERSION: 1.47.0
+          TYPOS_SHA256: 6f8a935cea6c60b060082b862a7e777bfd92d939a4fd4194d8085b086dfe24e4  # pragma: allowlist secret
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -310,7 +310,7 @@ kinto
 **Bug fixes**
 
 - Restore ``group_check_enabled`` field in ``"signer"`` capability for backward
-  compability with previous versions (#1962)
+  compatibility with previous versions (#1962)
 
 **Internal Changes**
 
@@ -513,7 +513,7 @@ kinto
 
 **Documentation**
 
-- Fix "negociation" typo in docs/images/architecture.svg (Kinto/kinto#2813)
+- Fix "negotiation" typo in docs/images/architecture.svg (Kinto/kinto#2813)
 
 **Internal changes**
 
@@ -1165,7 +1165,7 @@ kinto
 
 **Bug fixes**
 
-- Fix apparence of Admin notifications (Kinto/kinto#2191)
+- Fix appearance of Admin notifications (Kinto/kinto#2191)
 
 
 17.1.2 (2019-07-03)
@@ -2057,7 +2057,7 @@ kinto-admin
 
 - Fix signoff workflow info when kinto-signer running on server is >= 3.2 (Kinto/kinto-admin#500)
 - Better detection of authentication failures (Kinto/kinto-admin#330)
-- Fix history table apparence (Kinto/kinto-admin#511)
+- Fix history table appearance (Kinto/kinto-admin#511)
 - Wrap signoff comment (Kinto/kinto-admin#490)
 
 
@@ -2722,7 +2722,7 @@ API is now at version **1.17**. See `API changelog <http://kinto.readthedocs.io/
   specified users only makes sense if those users are "admins", which
   means they're in ``account_write_principals``. (Kinto/kinto#1281)
 - Fix a 500 when accounts without an ID are created (Kinto/kinto#1280).
-- Fix StatsD unparseable metric packets for the unique user counter (Kinto/kinto#1282)
+- Fix StatsD unparsable metric packets for the unique user counter (Kinto/kinto#1282)
 - Fix permissions endpoint when using account plugin (Kinto/kinto#1276)
 - Fix missing ``collection_count`` field in the rebuild-quotas script.
 - Fix bug causing validation to always succeed if no required fields are present.
@@ -3172,7 +3172,7 @@ Protocol is now at version **1.15**. See `API changelog`_.
 - Prevent injections in the PostgreSQL permission backend (Kinto/kinto#1061)
 - Fix crash on ``If-Match: *`` (Kinto/kinto#1064)
 - Handle Integer overflow in querystring parameters. (Kinto/kinto#1076)
-- Flush endpoint now returns an empty JSON object instad of an HTML page (Kinto/kinto#1098)
+- Flush endpoint now returns an empty JSON object instead of an HTML page (Kinto/kinto#1098)
 - Fix nested sorting key breaks pagination token. (Kinto/kinto#1116)
 - Remove ``deleted`` field from ``PUT`` requests over tombstones. (Kinto/kinto#1115)
 - Fix crash when preconditions are used on the permission endpoint (Kinto/kinto#1066)
@@ -3381,7 +3381,7 @@ kinto-fxa
 
 **Bug fixes**
 
-- Make sure that caching of token verification nevers prevents from authenticating
+- Make sure that caching of token verification never prevents from authenticating
   requests (see Mozilla/PyFxA#48)
 
 
@@ -3809,7 +3809,7 @@ Kinto
   has been deployed. Its location can be specified in the ``kinto.version_json_path``
   setting (fixes #830)
 - New built-in plugin ``kinto.plugins.history`` to track history of changes per bucket
-  from the Kinto Admin UI (*must be added explicity in the ``kinto.includes`` setting*)
+  from the Kinto Admin UI (*must be added explicitly in the ``kinto.includes`` setting*)
 - ``kinto migrate`` now accepts a ``--dry-run`` option which details the operations
   to be made without executing them.
 - New built-in plugin ``kinto.plugins.quotas`` to set storage quotas per bucket/collection
@@ -3914,7 +3914,7 @@ Kinto
 **Bug fixes**
 
 - Fix Redis get_accessible_object implementation (kinto/kinto#725)
-- Fix bug where the resource events of a request targetting two groups/collection
+- Fix bug where the resource events of a request targeting two groups/collection
   from different buckets would be grouped together (kinto/kinto#728)
 
 
@@ -3992,7 +3992,7 @@ Kinto
 
 **Bug fixes**
 
-- Fix bug where the resource events of a request targetting two groups/collection
+- Fix bug where the resource events of a request targeting two groups/collection
   from different buckets would be grouped together (#728).
 - Allow filtering and sorting by any attribute on buckets, collections and groups list endpoints
 - Fix crash in memory backend with Python3 when filtering on unknown field
@@ -4093,7 +4093,7 @@ API is now at version **1.7**. See `API changelog <http://kinto.readthedocs.io/e
 - Fix internal storage filtering when an empty list of values is provided.
 - Authenticated users are now allowed to obtain an empty list of buckets on
   ``GET /buckets`` even if no bucket is readable (#454)
-- Fix enabling flush enpoint with ``KINTO_FLUSH_ENDPOINT_ENABLED`` environment variable (fixes #588)
+- Fix enabling flush endpoint with ``KINTO_FLUSH_ENDPOINT_ENABLED`` environment variable (fixes #588)
 - Fix reading settings for events listeners from environment variables (fixes #515)
 - Fix principal added to ``write`` permission when a publicly writable object
   is created/edited (fixes #645)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SPHINX_BUILDDIR = docs/_build
 PSQL_INSTALLED := $(shell psql --version 2>/dev/null)
 SOURCES := kinto-remote-settings kinto-slack cronjobs git-reader browser-tests bin
 TY_SOURCES := kinto-remote-settings kinto-slack cronjobs git-reader bin
+TYPOS_INSTALLED := $(shell typos --version 2>/dev/null)
 
 help:
 	@echo "Please use 'make <target>' where <target> is one of the following commands.\n"
@@ -39,6 +40,11 @@ lint: $(INSTALL_STAMP)  ## Analyze code base
 	$(VENV)/bin/ruff check $(SOURCES)
 	$(VENV)/bin/ruff format $(SOURCES)
 	$(VENV)/bin/ty check $(TY_SOURCES)
+ifndef TYPOS_INSTALLED
+	$(warning "'typos' is not available please install typos-cli")
+else
+	typos `git ls-files | grep -v -E '.png|.jpg|.jpeg|.webm'`
+endif
 	$(VENV)/bin/detect-secrets-hook `git ls-files | grep -v uv.lock` --baseline .secrets.baseline
 	$(VENV)/bin/python bin/repo-python-versions.py
 

--- a/cronjobs/tests/commands/test_git_export.py
+++ b/cronjobs/tests/commands/test_git_export.py
@@ -803,7 +803,7 @@ def test_repo_syncs_deletes_attachments_if_flag_set(
 
 
 @responses.activate
-def test_repo_is_resetted_to_local_content_on_error(
+def test_repo_is_reset_to_local_content_on_error(
     capsys,
     repo,
     mock_git_fetch,

--- a/docs/adr/adr_003_bundling_collection_data.md
+++ b/docs/adr/adr_003_bundling_collection_data.md
@@ -107,7 +107,7 @@ References
 - [Download of all addons suggestions files](https://searchfox.org/mozilla-central/rev/8ec3cc0472ad4f51b254728d024b696eaba82ba0/browser/components/urlbar/private/AddonSuggestions.sys.mjs#87-101)
 
 ### Metrics To Measure Before/After
-We want to measure CPU usage, total bandwidth used, duration of syncronization on fresh profiles, and battery usage for full synchronization. We should be able to gather most of this by running power and performance profiles on different hardware.
+We want to measure CPU usage, total bandwidth used, duration of synchronization on fresh profiles, and battery usage for full synchronization. We should be able to gather most of this by running power and performance profiles on different hardware.
 
 Hardware to include:
 - Mac Desktop/Laptop
@@ -137,7 +137,7 @@ None at this time
 
 ## Considered Options
 1. Synchronously build bundles on attachment upload/removal (in request / response cycle)
-2. Aynchronously build bundles on attachment upload/removal (via Cloud Storage event)
+2. Asynchronously build bundles on attachment upload/removal (via Cloud Storage event)
 3. Build bundles on RS changes approval
 4. Add new API endpoint to build or serve last bundle
 5. Build bundles on schedule
@@ -230,6 +230,4 @@ The clients would pull the records bundle on first sync, and the attachments bun
 - Not so good, because we would introduce some coupling with kinto-attachment config (unless we mount the same RS server .ini config in the container and read conf from it) 
 - Not so good, because if we don’t couple it with the push timestamp cronjob, there could be a window of time where the bundle for a particular timestamp is not yet available
 - Bad, because this would be a remote-settings specific job and feature, and not part of kinto-attachment
-- Not so bad, because it would live along other cronjobs, and would be close to the one that syncs the timestamp with the push server  
-
-
+- Not so bad, because it would live along other cronjobs, and would be close to the one that syncs the timestamp with the push server

--- a/docs/adr/adr_005_database_objects.md
+++ b/docs/adr/adr_005_database_objects.md
@@ -227,4 +227,4 @@ These replicas would not have exactly the data they need as in option 3. But we 
 - **Complexity**: Low.
 - **Cost of implementation**: Low. Small changes in terraform and helm.
 - **Cost of operation**: Low. Costs should not increase and may decrease slightly since we can downscale the main instance.
-- **Future-resilience**: Medium-High. We can independetly scale the reader replicas. Our workload is 99% read and 1% write, so the ability to scale the readers specifically is nice. We could also implement autoscaling in the future (if needed) with some alert listeners that would change cloud state.
+- **Future-resilience**: Medium-High. We can independently scale the reader replicas. Our workload is 99% read and 1% write, so the ability to scale the readers specifically is nice. We could also implement autoscaling in the future (if needed) with some alert listeners that would change cloud state.

--- a/docs/adr/adr_007_broadcast_debounce.md
+++ b/docs/adr/adr_007_broadcast_debounce.md
@@ -86,7 +86,7 @@ To choose our solution, we considered the following criteria:
 
 ## Decision Outcome
 
-Chosen option: **Option 10**, consisting in runing a tiny Memcached container.
+Chosen option: **Option 10**, consisting in running a tiny Memcached container.
 
 Although all options have their merits, this approach offers a good balance between complexity and cost. The debouncing logic remains in the application layer, no code changes are required, since Kinto has a built-in support for Memcached, making it a very simple solution easy to reason about. Memcached is lighter than Redis, and since we can afford losing cached data, we don't need to worry about persistence or high availability.
 
@@ -140,7 +140,7 @@ The broadcast endpoint serves a `3XX Redirect` to the GCS file.
 
 - **Complexity**: Mid. We can control the frequency of broadcasts by controlling how often we update the file on GCS. However, it introduces a new moving part (the cronjob), but we already have Telescope checks in place to monitor the broadcasted value.
 - **Cost of implementation**: Low. We already have the code to write files on GCS. We already have scheduled jobs.
-- **Cost of operation**: Low. GCS is cheap to use, and we would only write a file every 5min, which is negligible in terms of cost. It would also remove the current trafic on our origins.
+- **Cost of operation**: Low. GCS is cheap to use, and we would only write a file every 5min, which is negligible in terms of cost. It would also remove the current traffic on our origins.
 - **Scalability**: High. Serving a redirect is cheap, and GCS can handle a large number of requests without any issue.
 
 Concerns:

--- a/docs/adr/adr_008_git-readers.md
+++ b/docs/adr/adr_008_git-readers.md
@@ -337,7 +337,7 @@ However, **additional collections or changes on records are not supported** (yet
 
 ## For Firefox Enterprise
 
-In the context of *Firefox Enterprise*, the components described in this document becomes a buiilding brick of the Firefox Enterprise Console.
+In the context of *Firefox Enterprise*, the components described in this document becomes a building brick of the Firefox Enterprise Console.
 
 The Remote Settings team would:
 

--- a/docs/case-studies.rst
+++ b/docs/case-studies.rst
@@ -60,7 +60,7 @@ Implementation
 
 Addons blocklist implemented using a bloomfilter (`docs <https://github.com/mozilla/addons-server/blob/ac50305b57a67c0e6ccb1ba121f223b007ccba15/docs/topics/blocklist.rst#bloomfilter-records>`_)
 
-* Bloomfilters are published from a Cron job on the addons-server, implementated using raw Python requests (`source <https://github.com/mozilla/addons-server/blob/d94705157627e0ed4b526fd1c9af5dfe7b7d362b/src/olympia/lib/remote_settings.py#L92-L120>`__)
+* Bloomfilters are published from a Cron job on the addons-server, implemented using raw Python requests (`source <https://github.com/mozilla/addons-server/blob/d94705157627e0ed4b526fd1c9af5dfe7b7d362b/src/olympia/lib/remote_settings.py#L92-L120>`__)
 
 * Incremental updates of bloomfilters are downloaded as binary attachments, full or base + stashes (`source <https://searchfox.org/mozilla-central/rev/8a4aa0c699d9ec281d1f576c9be1c6c1f289e4e7/toolkit/mozapps/extensions/Blocklist.jsm#1423-1456>`__)
 
@@ -80,13 +80,13 @@ Misc
 User Journey
 ------------
 
-Contextual features recommandations is managed via the ``cfr`` collection.
+Contextual features recommendations is managed via the ``cfr`` collection.
 
 
 Localization
 ''''''''''''
 
-* Contextual recommandations are published using translatable placeholders or string IDs
+* Contextual recommendations are published using translatable placeholders or string IDs
 
 ::
 
@@ -111,7 +111,7 @@ Localization
 
 * In parallel, localizations are published in a separate collection
 * Each locale has its own record, with its ID in the following format `` `cfr-v1-${locale}` `` and a Fluent file attached.
-* A specificly instantiated downloader fetches the relevant one and reloads l10n (`source <https://searchfox.org/mozilla-central/rev/8a4aa0c699d9ec281d1f576c9be1c6c1f289e4e7/browser/components/newtab/lib/ASRouter.jsm#302-320>`__)
+* A specifically instantiated downloader fetches the relevant one and reloads l10n (`source <https://searchfox.org/mozilla-central/rev/8a4aa0c699d9ec281d1f576c9be1c6c1f289e4e7/browser/components/newtab/lib/ASRouter.jsm#302-320>`__)
 * This specific record is checked on each load, attachment is downloaded only if updated/missing/corrupted (built-in feature of attachment downloader)
 
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -164,7 +164,7 @@ Alternatively, if you have access to the `remote-settings-permissions <https://g
 
 .. code-block:: bash
 
-    ./manage.py deletecollection COLECTION_NAME
+    ./manage.py deletecollection COLLECTION_NAME
 
 And open a pull-request with the command output as description (See `this example <https://github.com/mozilla/remote-settings-permissions/pull/748>_`).
 

--- a/docs/screencasts/modify-request-review.vtt
+++ b/docs/screencasts/modify-request-review.vtt
@@ -16,7 +16,7 @@ The three possible review states are shown on top
 We will create a record
 
 00:00:30.000 --> 00:00:35.000
-with arbritary data
+with arbitrary data
 
 00:00:40.000 --> 00:00:46.000
 We will delete another also

--- a/kinto-remote-settings/README.rst
+++ b/kinto-remote-settings/README.rst
@@ -63,7 +63,7 @@ distinguish changes from several Kinto instances.
 By default, it will rely on the global setting ``kinto.http_host``.
 
 
-**_since sanetizing**
+**_since sanitizing**
 
 When reaching the monitor/changes collection, if the provided ``_since`` query parameter
 is too old, we redirect the clients to the full list of changes (ie. without ``_since``).
@@ -290,7 +290,7 @@ makes sure that:
 
 See `Kinto groups API <http://kinto.readthedocs.io/en/stable/api/1.x/groups.html>`_ for more details about how to define groups.
 
-The above settings can be set or overriden by bucket using the ``<bucket_id>_`` prefix or by collection using the ``<bucket_id>_<collection_id>_`` prefix.
+The above settings can be set or overridden by bucket using the ``<bucket_id>_`` prefix or by collection using the ``<bucket_id>_<collection_id>_`` prefix.
 For example:
 
 .. code-block:: ini

--- a/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/changes/views.py
@@ -321,7 +321,7 @@ class ChangeSetRoute(RouteFactory):
         self.required_permission = "read"
 
     def check_permission(self, principals, bound_perms):
-        # The monitor/changes changeset endpoint is publicly accesible.
+        # The monitor/changes changeset endpoint is publicly accessible.
         if self.permission_object_id == CHANGES_COLLECTION_PATH:
             return True
         # Otherwise rely on the collection permissions.
@@ -535,7 +535,7 @@ broadcasts = Service(name="broadcast", path="/__broadcasts__", description="broa
 )
 def broadcasts_view(request):
     """
-    Implement the old Megaphone broacast endpoint,that the Push service will pull.
+    Implement the old Megaphone broadcast endpoint,that the Push service will pull.
 
     See https://github.com/mozilla-services/megaphone?tab=readme-ov-file#get-v1broadcasts
     """

--- a/kinto-remote-settings/src/kinto_remote_settings/signer/__init__.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/signer/__init__.py
@@ -145,7 +145,7 @@ def load_signed_resources_configuration(config):
             )
         )
         # Keep the `to_review_enabled` field in the resource object
-        # only if it was overriden. In other words, this will be exposed in
+        # only if it was overridden. In other words, this will be exposed in
         # the capabilities if the resource's review setting is different from
         # the global server setting.
         if resource_to_review_enabled != global_settings["to_review_enabled"]:

--- a/kinto-remote-settings/src/kinto_remote_settings/signer/backends/__init__.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/signer/backends/__init__.py
@@ -5,7 +5,7 @@ logger = logging.getLogger(__name__)
 
 
 def heartbeat(request):
-    """Test that signer is operationnal.
+    """Test that signer is operational.
 
     :param request: current request object
     :type request: :class:`~pyramid:pyramid.request.Request`

--- a/kinto-remote-settings/src/kinto_remote_settings/signer/listeners.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/signer/listeners.py
@@ -36,7 +36,7 @@ def pick_resource_and_signer(request, resources, bucket_id, collection_id):
 
     resource = signer = None
 
-    # Review might have been configured explictly for this collection,
+    # Review might have been configured explicitly for this collection,
     if collection_key in resources:
         resource = resources[collection_key]
     elif bucket_key in resources:
@@ -127,7 +127,7 @@ def sign_collection_data(event, resources, **kwargs):
         new_status = new_collection.get("status")
         old_status = old_collection.get("status")
 
-        # Autorize kinto-attachment metadata write access. #190
+        # Authorize kinto-attachment metadata write access. #190
         event.request._attachment_auto_save = True
 
         # Logger JSON fields.

--- a/kinto-remote-settings/tests/changes/test_changes.py
+++ b/kinto-remote-settings/tests/changes/test_changes.py
@@ -97,7 +97,7 @@ class UpdateChangesTest(BaseWebTest, unittest.TestCase):
             resp = self.app.get(self.changes_uri)
         assert len(resp.json["data"]) == 1
 
-    def test_returns_200_with_empty_list_of_changes_if_no_change_occured(self):
+    def test_returns_200_with_empty_list_of_changes_if_no_change_occurred(self):
         resp = self.app.get(self.changes_uri)
         before_timestamp = resp.headers["ETag"]
 
@@ -206,7 +206,7 @@ class CacheExpiresTest(BaseWebTest, unittest.TestCase):
 
     def test_cache_expires_header_is_default_with_concurrency_control(self):
         # The `If-None-Match` header is just a way to obtain a 304 instead of a 200
-        # with an empty list. In the client code [0] it is always used in conjonction
+        # with an empty list. In the client code [0] it is always used in conjunction
         # with _since={last-etag}
         # [0] https://searchfox.org/mozilla-central/rev/93905b66/services/settings/Utils.jsm#70-73
         headers = {"If-None-Match": f'"{HOUR_AGO}"'}

--- a/kinto-remote-settings/tests/signer/test_events.py
+++ b/kinto-remote-settings/tests/signer/test_events.py
@@ -229,7 +229,7 @@ class ResourceEventsTest(BaseWebTest, unittest.TestCase):
         assert len(events[0].impacted_objects) == 2
         updated = events[0].impacted_objects[0]
         assert "old" not in updated
-        assert updated["new"]["title"], ("bonjour", "hel ino")
+        assert updated["new"]["title"] == "hello"
 
     def test_resource_changed_is_triggered_for_destination_update(self):
         record_uri = self.source_collection + "/records/xyz"

--- a/kinto-remote-settings/tests/signer/test_signoff_flow.py
+++ b/kinto-remote-settings/tests/signer/test_signoff_flow.py
@@ -171,7 +171,7 @@ class CollectionStatusTest(SignoffWebTest, FormattedErrorMixin, unittest.TestCas
             {"data": {"status": "to-sign"}},
             headers=self.headers,
         )
-        # Signature occured, the source collection will be signed.
+        # Signature occurred, the source collection will be signed.
         self.app.patch_json(
             self.source_collection, {"data": {"status": "signed"}}, headers=self.headers
         )
@@ -1438,7 +1438,7 @@ class PerBucketTest(SignoffWebTest, unittest.TestCase):
         ]
         assert data["status"] == "signed"
 
-    def test_review_settings_can_be_overriden_for_a_specific_collection(self):
+    def test_review_settings_can_be_overridden_for_a_specific_collection(self):
         # review is not enabled for this particular one, sign directly!
         self.app.put_json(
             self.source_bucket + "/collections/specific",
@@ -1556,16 +1556,16 @@ class GroupCreationTest(PostgresWebTest, unittest.TestCase):
 
     def test_groups_are_not_touched_if_already_exist(self):
         resp = self.app.put(self.editors_group, headers=self.headers)
-        editors_timetamp = resp.json["data"]["last_modified"]
+        editors_timestamp = resp.json["data"]["last_modified"]
         resp = self.app.put(self.reviewers_group, headers=self.headers)
-        reviewers_timetamp = resp.json["data"]["last_modified"]
+        reviewers_timestamp = resp.json["data"]["last_modified"]
 
         self.app.put(self.source_collection, headers=self.headers)
 
         r = self.app.get(self.editors_group, headers=self.headers).json
-        assert r["data"]["last_modified"] == editors_timetamp
+        assert r["data"]["last_modified"] == editors_timestamp
         r = self.app.get(self.reviewers_group, headers=self.headers).json
-        assert r["data"]["last_modified"] == reviewers_timetamp
+        assert r["data"]["last_modified"] == reviewers_timestamp
 
     def test_collection_creation_is_rejected_if_user_cannot_create_groups(self):
         # Allow this other user to create collections only (no group:create).

--- a/kinto-remote-settings/tests/signer/test_utils.py
+++ b/kinto-remote-settings/tests/signer/test_utils.py
@@ -266,6 +266,7 @@ def test_expand_collections_glob_settings():
     }
 
 
+# spellchecker:off  # noqa: ERA001
 CERT_PEM = """-----BEGIN CERTIFICATE-----
 MIIC8zCCAnmgAwIBAgIIGGahTB7ZjAEwCgYIKoZIzj0EAwMwgZExCzAJBgNVBAYT
 AlVTMRwwGgYDVQQKExNNb3ppbGxhIENvcnBvcmF0aW9uMT0wOwYDVQQLEzRNb3pp
@@ -285,6 +286,7 @@ pnMhAJ0cY4J9RNss/K4qDAsmXZqW+6X4+ypewLu7L3cqqvVhkwIwKWhK1duubw0H
 W1fctdT/ReRcPz/W6vwR/YF9km1eoE/aZmktKmJos08cbythx22O
 -----END CERTIFICATE-----
 """
+# spellchecker:on  # noqa: ERA001
 
 
 def test_fetch_cert():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,3 +122,9 @@ pythonpath = ["git-reader", "cronjobs"]
 
 [tool.pytest_env]
 SENTRY_DSN = "https://fake:secret@sentry.example.com/001" # pragma: allowlist secret
+
+[tool.typos.default]
+extend-ignore-re = [
+    # Ignore blocks between `# spellchecker:off` and `# spellchecker:on`
+    "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on",
+]


### PR DESCRIPTION
Added `typos` in CI.

Ran it locally with `-w` to fix typos. 

Shall we add it to `make lint` (and thus expect developers to have it installed?)