### PR TITLE
Speed-up Python versions check

### DIFF
--- a/bin/repo-python-versions.py
+++ b/bin/repo-python-versions.py
@@ -1,4 +1,5 @@
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -23,11 +24,16 @@ def extract_versions_from_ci_workflow(file_path):
 
 
 def main():
+    result = subprocess.run(["git", "ls-files"], capture_output=True)
+    files = result.stdout.decode("utf8").splitlines()
+
     versions = []
-    for path in Path(".github/workflows").glob("*.y*ml"):
-        versions += extract_versions_from_ci_workflow(path)
-    for path in Path(".").rglob("*Dockerfile"):
-        versions += extract_versions_from_dockerfile(path)
+    for file in files:
+        path = Path(file)
+        if ".github/workflows" in file:
+            versions += extract_versions_from_ci_workflow(path)
+        elif "Dockerfile" in file:
+            versions += extract_versions_from_dockerfile(path)
 
     # We don't verify `pyproject.toml` files, since they provide a range
     # for developers convenience, and won't build if CI or Dockerfiles


### PR DESCRIPTION
I have tons of files in my local repo and it takes forever to run:

before
```
$ time .venv/bin/python bin/repo-python-versions.py
Extracted Python versions:
- 3.14.5
✅ Python versions are consistent.
.venv/bin/python bin/repo-python-versions.py  0.16s user 0.88s system 98% cpu 1.064 total
```

after
```
$ time .venv/bin/python bin/repo-python-versions.py
Extracted Python versions:
- 3.14.5
✅ Python versions are consistent.
.venv/bin/python bin/repo-python-versions.py  0.03s user 0.03s system 57% cpu 0.098 total
```