### PR TITLE
git-reader: RMST-438: do not always load Git repo when not self contained 

### DIFF
--- a/git-reader/app.py
+++ b/git-reader/app.py
@@ -779,7 +779,6 @@ def cert_chain(
     pem: str,
     response: Response,
     settings: Settings = Depends(get_settings),
-    git: GitService = Depends(GitService.dep),
 ):
     if not settings.self_contained:
         raise HTTPException(status_code=404, detail="cert-chains/ not enabled")
@@ -787,6 +786,12 @@ def cert_chain(
         response.headers["cache-control"] = (
             f"max-age={settings.cache_control_static_expires_seconds}"
         )
+        # Load the Git repo here and not via a FastAPI dependency,
+        # to avoid loading when self-contained.
+        repo = get_repo(
+            settings=settings, cache_bust=get_last_modified(settings=settings)
+        )
+        git = GitService.dep(repo=repo, settings=settings)
         return git.get_cert_chain(pem)
     except (FileNotFoundError, IsADirectoryError):
         raise HTTPException(status_code=404, detail=f"{pem} not found")
@@ -801,7 +806,6 @@ def attachments(
     request: Request,
     path: str,
     settings: Settings = Depends(get_settings),
-    git: GitService = Depends(GitService.dep),
 ):
     if not settings.self_contained:
         raise HTTPException(status_code=404, detail="attachments/ not enabled")
@@ -830,6 +834,12 @@ def attachments(
     # The startup bundle contains all collections changesets.
     # Their x5u URLs must be rewritten to point to this server.
     if path == STARTUP_BUNDLE_FILE:
+        # Load the Git repo here and not via a FastAPI dependency,
+        # to avoid loading it for the all 4XX responses cases above.
+        repo = get_repo(
+            settings=settings, cache_bust=get_last_modified(settings=settings)
+        )
+        git = GitService.dep(repo=repo, settings=settings)
         cached = request.state.cache.get("_cached_startup_bundle")
         current_commit: str = git.get_head_info()["id"]
         if cached != current_commit:

--- a/git-reader/tests/test_api.py
+++ b/git-reader/tests/test_api.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 import tempfile
+from unittest import mock
 
 import pygit2
 import pytest
@@ -543,6 +544,19 @@ def test_cert_chain_404(api_client):
     assert resp.status_code == 404
 
 
+def test_cert_chain_without_self_contained_does_not_load_git(app, temp_dir):
+    from app import Settings, app, get_settings
+
+    app.dependency_overrides[get_settings] = lambda: Settings(
+        self_contained=False, git_repo_path=temp_dir
+    )
+    with mock.patch("app.pygit2.Repository") as mocked_git:
+        with TestClient(app=app, base_url="http://test") as client:
+            resp = client.get("/v2/cert-chains/a/b/unknown.pem")
+    assert resp.status_code == 404
+    assert not mocked_git.called
+
+
 def test_startup_rewrites_x5u(api_client, temp_dir):
     with open(
         os.path.join(temp_dir, "attachments", "bundles", "startup.json.mozlz4"), "wb"
@@ -636,6 +650,19 @@ def test_metrics_traces_durations(api_client):
         'remotesettings_repository_read_latency_seconds_bucket{le="0.001",operation="get_file_content"}'
         in metrics_text
     )
+
+
+def test_attachments_without_self_contained_does_not_load_git(app, temp_dir):
+    from app import Settings, app, get_settings
+
+    app.dependency_overrides[get_settings] = lambda: Settings(
+        self_contained=False, git_repo_path=temp_dir
+    )
+    with mock.patch("app.pygit2.Repository") as mocked_git:
+        with TestClient(app=app, base_url="http://test") as client:
+            resp = client.get("/v2/attachments/unknown.file")
+    assert resp.status_code == 404
+    assert not mocked_git.called
 
 
 def test_repo_caching(temp_dir, app, api_client):


### PR DESCRIPTION
RMST-438 

This would at least prevent the repo to be reloaded for 4XX responses

This is only usefull when the timestamp of the Github repo path changes often or when a lot of new workers are spawn