### PR TITLE
Making git-reader return 206 for older expected than since values

### DIFF
--- a/git-reader/app.py
+++ b/git-reader/app.py
@@ -678,7 +678,7 @@ def monitor_changes(
 ):
     if _since and _expected > 0 and _expected < _since:
         raise HTTPException(
-            status_code=400,
+            status_code=206,
             detail="_expected must be superior to _since if both are provided",
         )
 
@@ -713,7 +713,7 @@ def collection_changeset(
 ):
     if _since and _expected > 0 and _expected < _since:
         raise HTTPException(
-            status_code=400,
+            status_code=206,
             detail="_expected must be superior to _since if both are provided",
         )
 

--- a/git-reader/tests/test_api.py
+++ b/git-reader/tests/test_api.py
@@ -417,7 +417,7 @@ def test_monitor_changes_view_filtered_bad_since(api_client):
     resp = api_client.get(
         "/v2/buckets/monitor/collections/changes/changeset?_since=223456789&_expected=123456789"
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 206
 
 
 def test_monitor_changes_negative_values(api_client):
@@ -491,7 +491,7 @@ def test_changeset_bad_since(api_client, since):
     resp = api_client.get(
         f"/v2/buckets/main/collections/password-rules/changeset?_since={since}&_expected=123456789"
     )
-    assert resp.status_code in (400, 422)
+    assert resp.status_code in (206, 422)
 
 
 @pytest.mark.parametrize("_expected", ["", "-1", "abc", '"42"'])


### PR DESCRIPTION
Git-reader should return a 206 instead of a 400 when clients request data with an older `_expected` value than the `_since` value.
This will mirror the existing v1 behavior, which is what clients are expecting.

Client-side code ([link](https://searchfox.org/firefox-main/source/services/settings/remote-settings.sys.mjs#462)) in `remote-settings.sys.mjs` is expecting a 400 to mean the etag should be cleared so it can resync. But this is a behavior change from v1.