### PR TITLE
git-reader - improve collection changeset performance by caching the sorted refs

### DIFF
--- a/git-reader/app.py
+++ b/git-reader/app.py
@@ -153,8 +153,8 @@ class Settings(BaseSettings):
         description="Sets the cache-control response header to max-age={value} for static content, like attachments. Default is 604800 (1 week)",
     )
     filter_refs_cache_size: int = Field(
-      500,
-      description="Number of filter_refs function results to cache. This filters git tags to a specific collection and is expensive to run per request."
+        500,
+        description="Number of filter_refs function results to cache. This filters git tags to a specific collection and is expensive to run per request.",
     )
 
 

--- a/git-reader/app.py
+++ b/git-reader/app.py
@@ -126,7 +126,7 @@ logging.config.dictConfig(
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore", frozen=True)
-    git_repo_path: str | None = Field(None, description="Path to the Git repository")
+    git_repo_path: str = Field("", description="Path to the Git repository")
     self_contained: bool = Field(
         False,
         description="Whether to serve `attachments/` and `cert-chains/` endpoints.",
@@ -291,7 +291,7 @@ def filter_refs(
     """
     Returns a list of git refs filtered to the requested bucket and collection,
     sorted in reverse chronological order. Because repo is provided as a param,
-    and that ref will chagne as content changes, this cache will not return
+    and that ref will change as content changes, this cache will not return
     stale data.
     """
     return sorted(

--- a/git-reader/app.py
+++ b/git-reader/app.py
@@ -126,7 +126,7 @@ logging.config.dictConfig(
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore", frozen=True)
-    git_repo_path: str = Field(..., description="Path to the Git repository")
+    git_repo_path: str | None = Field(None, description="Path to the Git repository")
     self_contained: bool = Field(
         False,
         description="Whether to serve `attachments/` and `cert-chains/` endpoints.",
@@ -151,6 +151,10 @@ class Settings(BaseSettings):
     cache_control_static_expires_seconds: int = Field(
         604800,
         description="Sets the cache-control response header to max-age={value} for static content, like attachments. Default is 604800 (1 week)",
+    )
+    filter_refs_cache_size: int = Field(
+      500,
+      description="Number of filter_refs function results to cache. This filters git tags to a specific collection and is expensive to run per request."
     )
 
 
@@ -278,7 +282,7 @@ def measure_git_read_time(operation: str):
     return decorator
 
 
-@lru_cache(maxsize=500)
+@lru_cache(maxsize=get_settings().filter_refs_cache_size)
 def filter_refs(
     repo: pygit2.Repository,
     bid: str,
@@ -286,7 +290,9 @@ def filter_refs(
 ) -> list[str]:
     """
     Returns a list of git refs filtered to the requested bucket and collection,
-    sorted in reverse chronological order.
+    sorted in reverse chronological order. Because repo is provided as a param,
+    and that ref will chagne as content changes, this cache will not return
+    stale data.
     """
     return sorted(
         [

--- a/git-reader/app.py
+++ b/git-reader/app.py
@@ -278,6 +278,28 @@ def measure_git_read_time(operation: str):
     return decorator
 
 
+@lru_cache(maxsize=500)
+def filter_refs(
+    repo: pygit2.Repository,
+    bid: str,
+    cid: str,
+) -> list[str]:
+    """
+    Returns a list of git refs filtered to the requested bucket and collection,
+    sorted in reverse chronological order.
+    """
+    return sorted(
+        [
+            ref.decode()
+            for ref in repo.raw_listall_references()
+            if ref.decode().startswith(
+                f"refs/tags/{GIT_REF_PREFIX}timestamps/{bid}/{cid}/"
+            )
+        ],
+        reverse=True,
+    )
+
+
 class GitService:
     """
     Wrapper on top of pygit2 to serve content.
@@ -343,16 +365,7 @@ class GitService:
         Get the changeset for a specific collection.
         """
         # List all tags for this collection and sort them by timestamp desc.
-        refs = sorted(
-            [
-                ref.decode()
-                for ref in self.repo.raw_listall_references()
-                if ref.decode().startswith(
-                    f"refs/tags/{GIT_REF_PREFIX}timestamps/{bid}/{cid}/"
-                )
-            ],
-            reverse=True,
-        )
+        refs = filter_refs(self.repo, bid, cid)
         if not refs:
             raise CollectionNotFound(bid, cid)
 


### PR DESCRIPTION
[RMST-438](https://mozilla-hub.atlassian.net/browse/RMST-438)
When investigating CPU spikes, found that the `raw_listall_references` call was responsible for 75% of the effort in `get_collection_changeset`.

Caching the results from this gives us a pretty good performance boost in some synthetic testing.

Tests were running jmeter with 100 threads in 100 loops.
```
Before:
Pull ms-images changeset: 3:45
Pull an invalid collection's changeset: 2:30

After:
Pull ms-images changeset: 1:40
Pull an invalid collection's changeset: 0:18
```