### PR TITLE
RMST-451 - adding debug log to git-reader/run.sh

### DIFF
--- a/git-reader/run.sh
+++ b/git-reader/run.sh
@@ -88,6 +88,9 @@ cmd_gitupdate() {
 git_fetch_lfs() {
     local repo_path="$1"
 
+    log("Current commit for $repo_path")
+    git -C $repo_path log -n 1
+
     # Remove Git lock if any. Or fetch will fail with "fatal: Unable to create '.../.git/index.lock': File exists."
     lock_file="$repo_path/.git/index.lock"
     if [ -f "$lock_file" ]; then


### PR DESCRIPTION
[RMST-451](https://mozilla-hub.atlassian.net/browse/RMST-451)

Investigating an issue where there is a delay in the git-reader update when updating the current primary folder.