### PR TITLE
Fix #1413: RMST-398: do not drop extensions on source/target folder and filenames

### DIFF
--- a/cronjobs/src/commands/build_compression_dictionaries.py
+++ b/cronjobs/src/commands/build_compression_dictionaries.py
@@ -101,10 +101,10 @@ def find_missing_compressed_files(
 
 
 def compressed_filename(pair: DictPair):
-    old_stem = Path(pair.old).stem
-    new_stem = Path(pair.new).stem
+    old_filename = Path(pair.old).name
+    new_filename = Path(pair.new).name
     # /cdt/{bid}/{cid}/compressed/target-{new}/dcz/from-{old}.dcz"
-    return f"{DESTINATION_FOLDER}/{pair.bid}/{pair.cid}/compressed/target-{new_stem}/dcz/from-{old_stem}.dcz"
+    return f"{DESTINATION_FOLDER}/{pair.bid}/{pair.cid}/compressed/target-{new_filename}/dcz/from-{old_filename}.dcz"
 
 
 def download_blob_to_file(

--- a/cronjobs/tests/commands/test_build_compression_dictionaries.py
+++ b/cronjobs/tests/commands/test_build_compression_dictionaries.py
@@ -178,7 +178,7 @@ def test_compressed_filename():
     )
     assert (
         filename
-        == "cdt/bid/cid/compressed/target-20260601--rid1--file1/dcz/from-20260201--rid1--file2.dcz"
+        == "cdt/bid/cid/compressed/target-20260601--rid1--file1.txt/dcz/from-20260201--rid1--file2.txt.dcz"
     )
 
 
@@ -238,7 +238,7 @@ def test_build_compression_dictionaries(
 
     mock_blob.assert_any_call(
         bucket=mock_storage_bucket,
-        name="cdt/bid/cid/compressed/target-20260601--rid1--file/dcz/from-20260101--rid1--file.dcz",
+        name="cdt/bid/cid/compressed/target-20260601--rid1--file.txt/dcz/from-20260101--rid1--file.txt.dcz",
     )
     mock_blob.return_value.upload_from_file.assert_called_once_with(
         mock.ANY,


### PR DESCRIPTION

Fix #1413