### PR TITLE
git-export: RMST-480: tweak defaults for shorter history

### DIFF
--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -65,9 +65,9 @@ GIT_REMOTE_URL = config(
 SSH_PUBKEY_PATH = os.path.expanduser(
     config("SSH_PUBKEY_PATH", default=f"{SSH_PRIVKEY_PATH}.pub")
 )
-TAGS_MAX_AGE_DAYS = config("TAGS_MAX_AGE_DAYS", default=90, cast=int)
+TAGS_MAX_AGE_DAYS = config("TAGS_MAX_AGE_DAYS", default=30, cast=int)
 MIN_TAGS_PER_COLLECTION_COUNT = config(
-    "MIN_TAGS_PER_COLLECTION_COUNT", default=2, cast=int
+    "MIN_TAGS_PER_COLLECTION_COUNT", default=3, cast=int
 )
 # We truncate and force push the common branch only every 50 publications (a few days).
 # This is to avoid excessive rewriting of history. Truncating is only needed to


### PR DESCRIPTION
With the default 90 days:

```
Number of tags per collection (top 10):
   2706 v1/timestamps/common
   1096 v1/timestamps/main/nimbus-preview
   1096 v1/timestamps/main-preview/nimbus-preview
    395 v1/timestamps/main-preview/nimbus-desktop-experiments
    357 v1/timestamps/blocklists/addons-bloomfilters
    355 v1/timestamps/main/nimbus-desktop-experiments
    195 v1/timestamps/security-state-preview/cert-revocations
```

We definitely don't need so many synchronization points... especially because if a client pulls from an unknown timestamp, it gets redirected to the full collection. 

I would even consider reducing it to 20