### PR TITLE
git-reader: run `git clean` in `gitupdate` to remove untracked files

### DIFF
--- a/git-reader/run.sh
+++ b/git-reader/run.sh
@@ -197,6 +197,7 @@ git_fetch_lfs() {
     git -C "$repo_path" reset --hard "$ORIGIN_NAME/v1/common"
     log "Cleaning up repository..."
     git -C "$repo_path" remote prune "$ORIGIN_NAME"
+    git -C "$repo_path" clean -f -d
     git -C "$repo_path" gc --prune=now
     git -C "$repo_path" repack -Ad
 

--- a/git-reader/run.sh
+++ b/git-reader/run.sh
@@ -202,6 +202,7 @@ git_fetch_lfs() {
     git -C "$repo_path" repack -Ad
 
     if [ "${SELF_CONTAINED:-false}" = "true" ]; then
+        git -C "$repo_path" lfs version
         log "Fetching LFS objects..."
         git -C "$repo_path" lfs pull
         log "Pruning LFS objects..."


### PR DESCRIPTION
Locally if found a lot of untracked files, so I assumed it could happen on the server