### PR TITLE
RMST-497: Mitigate A-S client issue with tombstones

### DIFF
--- a/git-reader/app.py
+++ b/git-reader/app.py
@@ -430,7 +430,8 @@ class GitService:
             # Deleted records are shown as tombstones.
             # Note: we set an arbitrary `last_modified` value as a
             # mitigation solution to A-S clients expecting it
-            # although it is not needed and not part of specifications.
+            # although it is not needed and not part of specifications
+            # (v1/ API had the field but was never officially mentioned).
             for rid in old_records_by_id.keys():
                 filtered[rid] = {"id": rid, "deleted": True, "last_modified": 0}
             records_by_id = filtered

--- a/git-reader/app.py
+++ b/git-reader/app.py
@@ -428,9 +428,11 @@ class GitService:
                 elif old_record != record:
                     filtered[rid] = record
             # Deleted records are shown as tombstones.
-            # Note: we don't have `last_modified` but clients don't need it.
+            # Note: we set an arbitrary `last_modified` value as a
+            # mitigation solution to A-S clients expecting it
+            # although it is not needed and not part of specifications.
             for rid in old_records_by_id.keys():
-                filtered[rid] = {"id": rid, "deleted": True}
+                filtered[rid] = {"id": rid, "deleted": True, "last_modified": 0}
             records_by_id = filtered
 
         # Sort records by last_modified desc.

--- a/git-reader/tests/test_api.py
+++ b/git-reader/tests/test_api.py
@@ -526,7 +526,7 @@ def test_changeset_since(api_client):
     assert data["timestamp"] == 123456789
     assert data["changes"] == [
         {"id": "abc", "last_modified": 123456789, "foo": "bar"},
-        {"id": "def", "deleted": True},
+        {"id": "def", "deleted": True, "last_modified": 0},
     ]
 
 


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/RMST-497

- [Client specs](https://remote-settings.readthedocs.io/en/latest/client-specifications.html#local-state)
- [A-S client source](https://github.com/mozilla/application-services/blob/490bfb36c087698113502ce381dcfbb9aca7ec5c/components/remote_settings/src/client.rs#L819) does not have default on `last_modified` field
- [Desktop client](https://searchfox.org/firefox-main/rev/6cee80f87168d5aabd9e343099e2a8e5535e5320/services/settings/Database.sys.mjs#156)
- [RS team original rust client](https://github.com/mozilla-services/remote-settings-client/blob/2bc16799e475c71e6179a49536bf17b7554aea37/src/client.rs#L820-L821)