### PR TITLE
git-reader: RMST-501: fall back to nearest older timestamp instead of full changeset

### DIFF
--- a/git-reader/app.py
+++ b/git-reader/app.py
@@ -200,9 +200,9 @@ class CollectionNotFound(Exception):
     pass
 
 
-class UnknownTimestamp(Exception):
-    """Raised when timestamp requested with `_since` is does
-    not have any matching tag.
+class OldTimestampError(Exception):
+    """Raised when timestamp requested with `_since` is older
+    than any known timestamp.
     """
 
     pass
@@ -402,12 +402,31 @@ class GitService:
 
         # 2. If _since is provided, compare and hide unchanged records.
         if _since is not None:
-            since_ref = f"refs/tags/{GIT_REF_PREFIX}timestamps/{bid}/{cid}/{_since}"
-            try:
-                old_refobj = self.repo.lookup_reference(since_ref)
-            except KeyError:
-                # No such tag, this timestamp is unknown.
-                raise UnknownTimestamp(_since)
+            # Lookup the nearest older tag.
+            # If there is no tag for this exact timestamp (eg. it was deleted when
+            # old tags were pruned), we fall back to the most recent tag that is
+            # older than it.
+            # The returned changeset will contain unchanged records, which is
+            # harmless for clients since they are applied by id, but at least
+            # tombstones are not missed.
+            timestamps = [int(ref.split("/")[-1]) for ref in refs]
+            older_timestamps = [ts for ts in timestamps if ts <= _since]
+            if not older_timestamps:
+                # No tag older than this timestamp.
+                raise OldTimestampError(_since)
+            base_timestamp = max(older_timestamps)
+            if base_timestamp != _since:
+                logger.info(
+                    "No tag for %s/%s@%s, comparing with %s instead",
+                    bid,
+                    cid,
+                    _since,
+                    base_timestamp,
+                )
+            since_ref = (
+                f"refs/tags/{GIT_REF_PREFIX}timestamps/{bid}/{cid}/{base_timestamp}"
+            )
+            old_refobj = self.repo.lookup_reference(since_ref)
 
             old_tag = self.repo[old_refobj.target]
             old_commit = old_tag.peel(pygit2.Commit)
@@ -749,7 +768,7 @@ def collection_changeset(
         )
     except CollectionNotFound:
         raise HTTPException(status_code=404, detail=f"{bid}/{cid} not found")
-    except UnknownTimestamp:
+    except OldTimestampError:
         logger.info(
             "Unknown _since timestamp: %s for %s/%s, falling back to full changeset",
             _since,

--- a/git-reader/tests/test_api.py
+++ b/git-reader/tests/test_api.py
@@ -516,6 +516,32 @@ def test_changeset_unknown_since(api_client):
     )
 
 
+def test_changeset_since_unknown_fallsback_to_older_tag(api_client):
+    # No tag for 120000000, the 113456789 one is used instead.
+    resp = api_client.get(
+        "/v2/buckets/main/collections/password-rules/changeset?_expected=0&_since=120000000"
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["timestamp"] == 123456789
+    assert data["changes"] == [
+        {"id": "abc", "last_modified": 123456789, "foo": "bar"},
+        {"id": "def", "deleted": True, "last_modified": 0},
+    ]
+
+
+def test_changeset_since_newer_than_latest_returns_empty_list(api_client):
+    resp = api_client.get(
+        "/v2/buckets/main/collections/password-rules/changeset?_expected=0&_since=999999999"
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["timestamp"] == 123456789
+    assert data["changes"] == []
+
+
 def test_changeset_since(api_client):
     resp = api_client.get(
         "/v2/buckets/main/collections/password-rules/changeset?_expected=0&_since=113456789"

--- a/git-reader/tests/test_api.py
+++ b/git-reader/tests/test_api.py
@@ -516,7 +516,7 @@ def test_changeset_unknown_since(api_client):
     )
 
 
-def test_changeset_since_unknown_fallsback_to_older_tag(api_client):
+def test_changeset_since_unknown_fallbacks_to_older_tag(api_client):
     # No tag for 120000000, the 113456789 one is used instead.
     resp = api_client.get(
         "/v2/buckets/main/collections/password-rules/changeset?_expected=0&_since=120000000"


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/RMST-501