### PR TITLE
git-export: RMST-502: add tombstones to ledger files

### DIFF
--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -5,7 +5,7 @@ import os
 import traceback
 import urllib
 import urllib.parse
-from typing import Any, Iterable
+from typing import Any, Iterable, cast
 
 import kinto_http
 import pygit2
@@ -86,6 +86,7 @@ FORCE = config("FORCE", default=_SHOULD_FORCE, cast=bool)
 # Constants
 GIT_REF_PREFIX = "v1/"
 COMMON_BRANCH = "common"
+LEDGER_TIMESTAMP_SEPARATOR = "\t"
 _user, _email = GIT_AUTHOR.split("<")
 GIT_USER = _user.strip()
 GIT_EMAIL = _email.rstrip(">")
@@ -184,18 +185,30 @@ def json_dumpb(obj: Any) -> bytes:
 
 
 async def fetch_all_changesets(
-    client: kinto_http.AsyncClient, collections: Iterable[tuple[str, str]]
+    client: kinto_http.AsyncClient,
+    collections: Iterable[tuple[str, str]],
+    since: int,
 ) -> list[dict[str, Any]]:
     """
     Fetch the changesets of the specified collections using parallel requests.
+
+    With a `_since` value, the changesets also contain the tombstones of the
+    records deleted since then.
+
+    .. note::
+
+        /changeset endpoints don't support pagination, so they are more than
+        10K objects (records + tombstones) to fetch between two git-export runs,
+       then some data will be lost. Server configuration could be changed to
+       return 100K objects :)
     """
     sem = asyncio.Semaphore(MAX_PARALLEL_REQUESTS)
 
     async def fetch(bid: str, cid: str) -> dict[str, Any]:
         async with sem:
-            print("Fetching %s/%s" % (bid, cid))
+            print("Fetching %s/%s since %s" % (bid, cid, since))
             return await client.get_changeset(
-                bucket=bid, collection=cid, bust_cache=True
+                bucket=bid, collection=cid, _since=since, bust_cache=True
             )
 
     return await asyncio.gather(*[fetch(bid, cid) for bid, cid in collections])
@@ -266,8 +279,14 @@ async def repo_sync_content(
         if FORCE or entry["last_modified"] > latest_timestamp
     ]
     print(f"{len(new_changesets)} collections changed since last sync.")
+    # On a full sync we want the whole content of every collection, to refresh the
+    # attachments pointers and detect the orphan ones. Otherwise, we fetch
+    # only the changes and tombstones published since the last run.
+    fetch_since = 0 if FORCE else latest_timestamp
     all_changesets = await fetch_all_changesets(
-        client, [(entry["bucket"], entry["collection"]) for entry in new_changesets]
+        client,
+        [(entry["bucket"], entry["collection"]) for entry in new_changesets],
+        since=fetch_since,
     )
 
     # Store the broadcast version in `common` branch.
@@ -497,29 +516,75 @@ def process_attachments(
     return changed_attachments, common_content
 
 
+def tombstones_to_ledger_files(
+    branch_tree: pygit2.Tree | None,
+    cid: str,
+    tombstones: list[tuple[str, int]],
+) -> list[tuple[str, bytes | None]]:
+    """
+    Merge the tombstones into the ledger files of the collection, one per month.
+
+    Each entry goes to the file of its own month, since git-reader relies on
+    file names to locate the most recent deletion without reading them all.
+    """
+    by_month: dict[str, set[tuple[int, str]]] = {}
+    for rid, timestamp in tombstones:
+        month = ts2dt(timestamp).strftime("%Y%m")
+        by_month.setdefault(month, set()).add((timestamp, rid))
+
+    ledger_files: list[tuple[str, bytes | None]] = []
+    for month, entries in by_month.items():
+        path = f"{cid}/tombstones/{month}.txt"
+        known: set[tuple[int, str]] = set()
+        if branch_tree is not None:
+            try:
+                blob = cast(pygit2.Blob, branch_tree[path])
+            except KeyError:
+                pass  # First deletion of this month.
+            else:
+                for line in blob.data.decode("utf-8").splitlines():
+                    timestamp, rid = line.rsplit(LEDGER_TIMESTAMP_SEPARATOR, 1)
+                    known.add((int(timestamp), rid))
+
+        merged = known | entries
+        if merged == known:
+            # Nothing new: a full sync repeats every tombstone of the collection.
+            continue
+
+        ledger_files.append(
+            (
+                path,
+                "".join(
+                    f"{timestamp}{LEDGER_TIMESTAMP_SEPARATOR}{rid}\n"
+                    for timestamp, rid in sorted(merged)
+                ).encode("utf-8"),
+            )
+        )
+
+    return ledger_files
+
+
 def changeset_to_branch_folder(
     branch_tree: pygit2.Tree | None, changeset: dict[str, Any]
 ) -> list[tuple[str, bytes | None]]:
     """
     Convert a changeset to a list of files to be stored in the corresponding branch folder.
     """
-    # Create one blob per record.
     cid = changeset["metadata"]["id"]
     branch_content: list[tuple[str, bytes | None]] = [
         (f"{cid}/metadata.json", json_dumpb(changeset["metadata"]))
     ]
-    records = sorted(changeset["changes"], key=lambda r: r["id"])
-    for record in records:
-        branch_content.append((f"{cid}/{record['id']}.json", json_dumpb(record)))
 
-    # Delete any records that were removed in this changeset.
-    # (branch_tree is None on first run, and `cid` folder may not exist yet)
-    if branch_tree is not None and cid in branch_tree:
-        for entry in branch_tree[cid]:  # ty: ignore[not-iterable]
-            assert entry.name is not None
-            basename = entry.name.rsplit(".json", 1)[0]
-            if basename != "metadata" and basename not in {r["id"] for r in records}:
-                branch_content.append((f"{cid}/{entry.name}", None))
+    # Create one blob per record, and remove the ones that were deleted.
+    tombstones = []
+    for record in sorted(changeset["changes"], key=lambda r: r["id"]):
+        if record.get("deleted"):
+            branch_content.append((f"{cid}/{record['id']}.json", None))
+            tombstones.append((record["id"], record["last_modified"]))
+        else:
+            branch_content.append((f"{cid}/{record['id']}.json", json_dumpb(record)))
+
+    branch_content += tombstones_to_ledger_files(branch_tree, cid, tombstones)
 
     return branch_content
 

--- a/cronjobs/tests/commands/test_git_export.py
+++ b/cronjobs/tests/commands/test_git_export.py
@@ -9,6 +9,7 @@ import pygit2
 import pytest
 import responses
 from commands import git_export
+from commands._git_export_git_tools import tree_upsert_blobs
 
 
 @pytest.fixture(autouse=True)
@@ -222,6 +223,20 @@ def read_file(repo, ref_or_branch_name, filepath):
         obj = repo[entry.id]
         node = obj
     return obj.data
+
+
+def build_tree(repo, items):
+    """Build a tree from a list of (path, content) tuples."""
+    return repo[tree_upsert_blobs(repo, items, base_tree=None)]
+
+
+def changeset(cid, records):
+    """Minimal changeset for the specified collection."""
+    return {
+        "metadata": {"id": cid, "bucket": "main"},
+        "timestamp": 100,
+        "changes": records,
+    }
 
 
 def init_fake_repo(path):
@@ -686,8 +701,10 @@ def test_repo_sync_deletes_records_from_past_runs(
                 },
                 "last_modified": 1888888888000,
             },
-            # Record was deleted (we don't use `_since`, so no tombstone)
-            "changes": [],
+            # Record was deleted: with `_since`, the changeset has its tombstone.
+            "changes": [
+                {"id": "rid2-1", "deleted": True, "last_modified": 1800000000000}
+            ],
         },
     )
 
@@ -698,6 +715,61 @@ def test_repo_sync_deletes_records_from_past_runs(
         read_file(
             repo, "refs/tags/v1/timestamps/bid2/cid2/1800000000000", "cid2/rid2-1.json"
         )
+
+
+@responses.activate
+def test_repo_sync_appends_tombstones_to_the_ledger(
+    repo,
+    mock_git_fetch,
+    mock_list_heads,
+    mock_rs_server_content,
+    mock_github_lfs,
+    mock_git_push,
+):
+    git_export.git_export()
+    simulate_pushed(repo, mock_list_heads)
+
+    # No record was deleted yet, the collection has no ledger.
+    with pytest.raises(KeyError):
+        read_file(repo, "v1/buckets/bid2", "cid2/tombstones/202701.txt")
+
+    # Now simulate that cid2 deleted its record.
+    responses.replace(
+        responses.GET,
+        "http://testserver:9999/v1/buckets/monitor/collections/changes/changeset",
+        json={
+            "timestamp": 1800000000000,
+            "changes": [
+                {
+                    "last_modified": 1800000000000,
+                    "bucket": "bid2",
+                    "collection": "cid2",
+                }
+            ],
+        },
+    )
+    responses.add(
+        responses.GET,
+        "http://testserver:9999/v1/buckets/bid2/collections/cid2/changeset",
+        json={
+            "timestamp": 1800000000000,
+            "metadata": {
+                "bucket": "bid2",
+                "id": "cid2",
+                "signature": {"x5u": "https://autograph.example.com/keys/123"},
+                "last_modified": 1888888888000,
+            },
+            "changes": [
+                {"id": "rid2-1", "deleted": True, "last_modified": 1800000000000}
+            ],
+        },
+    )
+
+    git_export.git_export()
+
+    # 1800000000000 is 2027-01: the tombstone goes to the file of its own month.
+    ledger = read_file(repo, "v1/buckets/bid2", "cid2/tombstones/202701.txt")
+    assert ledger.decode() == "1800000000000\trid2-1\n"
 
 
 @responses.activate
@@ -959,3 +1031,123 @@ def test_repo_is_reset_to_local_content_on_error(
     )
     assert "Delete local tag refs/tags/v1/timestamps/bid1/cid0/1800000000000" in stdout
     assert "Delete local tag refs/tags/v1/timestamps/common/1800000000000" in stdout
+
+
+def test_tombstones_are_split_by_month_and_stored_in_ascending_order(repo):
+    files = git_export.tombstones_to_ledger_files(
+        None,
+        "cid",
+        # 1733000000000 is 2024-11, 1736000000000 is 2025-01.
+        [("ccc", 1737000000002), ("bbb", 1736000000000), ("aaa", 1733000000000)],
+    )
+
+    assert dict(files) == {
+        "cid/tombstones/202411.txt": b"1733000000000\taaa\n",
+        "cid/tombstones/202501.txt": b"1736000000000\tbbb\n1737000000002\tccc\n",
+    }
+
+
+def test_already_known_tombstones_are_deduped(repo):
+    tree = build_tree(
+        repo,
+        [("cid/tombstones/202501.txt", b"1736000000000\taaa\n1737000000001\tbbb\n")],
+    )
+
+    files = git_export.tombstones_to_ledger_files(
+        tree, "cid", [("aaa", 1736000000000), ("ccc", 1737000000002)]
+    )
+
+    # "aaa" is not repeated.
+    assert dict(files) == {
+        "cid/tombstones/202501.txt": (
+            b"1736000000000\taaa\n1737000000001\tbbb\n1737000000002\tccc\n"
+        )
+    }
+
+
+def test_ledger_file_is_not_rewritten_when_nothing_is_new(repo):
+    # A full sync repeats every tombstone of the collection.
+    tree = build_tree(repo, [("cid/tombstones/202501.txt", b"1736000000000\taaa\n")])
+
+    files = git_export.tombstones_to_ledger_files(tree, "cid", [("aaa", 1736000000000)])
+
+    assert files == []
+
+
+def test_changeset_to_branch_folder_removes_deleted_records(repo):
+    tree = build_tree(
+        repo,
+        [
+            ("cid/metadata.json", b"{}"),
+            ("cid/aaa.json", b"{}"),
+            ("cid/bbb.json", b"{}"),
+        ],
+    )
+
+    content = dict(
+        git_export.changeset_to_branch_folder(
+            tree,
+            changeset(
+                "cid",
+                [
+                    {"id": "aaa", "last_modified": 1737000000000},
+                    {"id": "bbb", "deleted": True, "last_modified": 1737000000001},
+                ],
+            ),
+        )
+    )
+
+    assert content["cid/bbb.json"] is None
+    assert content["cid/aaa.json"] is not None
+    # The deletion is recorded in the same set of files as the record removal.
+    assert content["cid/tombstones/202501.txt"] == b"1737000000001\tbbb\n"
+
+
+def test_changeset_to_branch_folder_appends_to_existing_ledger(repo):
+    tree = build_tree(
+        repo,
+        [
+            ("cid/metadata.json", b"{}"),
+            ("cid/bbb.json", b"{}"),
+            ("cid/tombstones/202501.txt", b"1736000000000\told\n"),
+        ],
+    )
+
+    content = dict(
+        git_export.changeset_to_branch_folder(
+            tree,
+            changeset(
+                "cid",
+                [{"id": "bbb", "deleted": True, "last_modified": 1737000000000}],
+            ),
+        )
+    )
+
+    assert content["cid/bbb.json"] is None
+    assert content["cid/tombstones/202501.txt"] == (
+        b"1736000000000\told\n1737000000000\tbbb\n"
+    )
+
+
+def test_changeset_to_branch_folder_ignores_already_known_tombstones(repo):
+    # A full sync (`_since=0`) repeats every tombstone of the collection.
+    tree = build_tree(
+        repo,
+        [
+            ("cid/metadata.json", b"{}"),
+            ("cid/tombstones/202501.txt", b"1736000000000\tbbb\n"),
+        ],
+    )
+
+    content = dict(
+        git_export.changeset_to_branch_folder(
+            tree,
+            changeset(
+                "cid",
+                [{"id": "bbb", "deleted": True, "last_modified": 1736000000000}],
+            ),
+        )
+    )
+
+    # Nothing appended, the ledger file is not even rewritten.
+    assert "cid/tombstones/202501.txt" not in content


### PR DESCRIPTION
See #1477 

First step for RMST-502: deploy this new git-export job that will store tombstones in ledgers files (see #1538).  Let it run a few times, stop it, run the backfill of #1545, restart the cronjob. 
At this point existing readers should work as usual. Then we can deploy the reader version of #1539 that reads from the ledger files.

