### PR TITLE
git-export: skip already deleted records on full syncs

### DIFF
--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -579,7 +579,12 @@ def changeset_to_branch_folder(
     tombstones = []
     for record in sorted(changeset["changes"], key=lambda r: r["id"]):
         if record.get("deleted"):
-            branch_content.append((f"{cid}/{record['id']}.json", None))
+            record_file = f"{cid}/{record['id']}.json"
+            # The file is missing from the branch if the record was already
+            # deleted in a previous run, or never published (eg. created and
+            # deleted between two runs). Full syncs repeat every tombstone.
+            if branch_tree is not None and record_file in branch_tree:
+                branch_content.append((record_file, None))
             tombstones.append((record["id"], record["last_modified"]))
         else:
             branch_content.append((f"{cid}/{record['id']}.json", json_dumpb(record)))

--- a/cronjobs/tests/commands/test_git_export.py
+++ b/cronjobs/tests/commands/test_git_export.py
@@ -1103,6 +1103,31 @@ def test_changeset_to_branch_folder_removes_deleted_records(repo):
     assert content["cid/tombstones/202501.txt"] == b"1737000000001\tbbb\n"
 
 
+@pytest.mark.parametrize("with_tree", [True, False])
+def test_changeset_to_branch_folder_ignores_missing_record_files(repo, with_tree):
+    # A full sync (`_since=0`) repeats tombstones of records that were never
+    # published in the branch, or already removed by a previous run.
+    tree = (
+        build_tree(repo, [("cid/metadata.json", b"{}")])  # No `cid/bbb.json`.
+        if with_tree
+        else None  # First run, the branch does not exist yet.
+    )
+
+    content = dict(
+        git_export.changeset_to_branch_folder(
+            tree,
+            changeset(
+                "cid",
+                [{"id": "bbb", "deleted": True, "last_modified": 1737000000000}],
+            ),
+        )
+    )
+
+    assert "cid/bbb.json" not in content
+    # The deletion is still recorded in the ledger.
+    assert content["cid/tombstones/202501.txt"] == b"1737000000000\tbbb\n"
+
+
 def test_changeset_to_branch_folder_appends_to_existing_ledger(repo):
     tree = build_tree(
         repo,


### PR DESCRIPTION
This is a regression introduced by #1546 

See https://mozilla.sentry.io/issues/7719640524/