### PR TITLE
git-export: Fix retrying and prevent to publish pointers if file was not uploaded

### DIFF
--- a/cronjobs/src/commands/_git_export_lfs.py
+++ b/cronjobs/src/commands/_git_export_lfs.py
@@ -22,6 +22,7 @@ HTTP_TIMEOUT_WRITE_SECONDS = config("HTTP_TIMEOUT_WRITE_SECONDS", default=600, c
 HTTP_RETRY_DELAY_SECONDS = config("HTTP_RETRY_DELAY_SECONDS", default=1, cast=float)
 HTTP_RETRY_MAX_COUNT = config("HTTP_RETRY_MAX_COUNT", default=10, cast=int)
 MAX_PARALLEL_REQUESTS = config("MAX_PARALLEL_REQUESTS", default=10, cast=int)
+MAX_PARALLEL_UPLOADS = config("MAX_PARALLEL_UPLOADS", default=6, cast=int)
 HTTP_TIMEOUT_SECONDS = (HTTP_TIMEOUT_CONNECT_SECONDS, HTTP_TIMEOUT_READ_SECONDS)
 HTTP_TIMEOUT_BATCH_SECONDS = (HTTP_TIMEOUT_CONNECT_SECONDS, HTTP_TIMEOUT_READ_SECONDS)
 HTTP_TIMEOUT_UPLOAD_SECONDS = (HTTP_TIMEOUT_CONNECT_SECONDS, HTTP_TIMEOUT_WRITE_SECONDS)
@@ -75,7 +76,7 @@ def _new_retrying_session() -> requests.Session:
         allowed_methods={"HEAD", "GET", "PUT", "POST", "DELETE", "OPTIONS", "TRACE"},
         raise_on_status=False,
     )
-    adapter = HTTPAdapter(max_retries=retries, pool_maxsize=MAX_PARALLEL_REQUESTS)
+    adapter = HTTPAdapter(max_retries=retries, pool_maxsize=MAX_PARALLEL_UPLOADS)
     session.mount("https://", adapter)
     return session
 
@@ -363,13 +364,15 @@ def github_lfs_batch_upload_many(
     repo_owner: str,
     repo_name: str,
     auth_header: str,
-    max_parallel_requests: int = MAX_PARALLEL_REQUESTS,
+    max_parallel_uploads: int = MAX_PARALLEL_UPLOADS,
 ) -> None:
     """
     Performs LFS batch 'upload' for up to GITHUB_MAX_LFS_BATCH_SIZE objects per batch,
     PUTs missing objects to the presigned destinations, and POSTs verify if provided.
 
     objects: iterable of (oid_hex:str, size:int, src_url:str)
+    max_parallel_uploads: how many objects are transferred concurrently. Lower it
+      when the LFS storage answers `503 Slow Down`.
     """
     chunks = list(itertools.batched(objects, GITHUB_MAX_LFS_BATCH_SIZE))
     total_chunks = len(chunks)
@@ -437,9 +440,9 @@ def github_lfs_batch_upload_many(
         _run_in_parallel(
             _download_from_cdn_and_upload_to_lfs_volume,
             to_upload,
-            max_parallel_requests,
+            max_parallel_uploads,
         )
-        _run_in_parallel(_github_lfs_verify_upload, to_verify, max_parallel_requests)
+        _run_in_parallel(_github_lfs_verify_upload, to_verify, max_parallel_uploads)
 
         print(
             f"LFS: {len(to_upload)} uploaded and {len(to_verify)} verified in chunk {idx}/{total_chunks}"

--- a/cronjobs/src/commands/_git_export_lfs.py
+++ b/cronjobs/src/commands/_git_export_lfs.py
@@ -41,8 +41,9 @@ def fetch_and_hash(url: str, dest_file: str | None = None) -> tuple[str, int]:
     print("Fetch attachment %r" % url)
     h = hashlib.sha256()
     total = 0
+    session = _new_retrying_session()
     with open(dest_file, "wb") as f:
-        with requests.get(url, stream=True, timeout=HTTP_TIMEOUT_SECONDS) as r:
+        with session.get(url, stream=True, timeout=HTTP_TIMEOUT_SECONDS) as r:
             r.raise_for_status()
             for chunk in r.iter_content(1024 * 64):
                 if not chunk:
@@ -55,7 +56,14 @@ def fetch_and_hash(url: str, dest_file: str | None = None) -> tuple[str, int]:
 
 def _new_retrying_session() -> requests.Session:
     """
-    Session tuned for GitHub LFS 'batch' and 'verify' calls.
+    Session that retries transient failures.
+
+    Used for every HTTP call of the export: a single 502 from the CDN or from a
+    presigned endpoint, among thousands of attachments, would otherwise abort
+    the whole run and discard all of its work.
+
+    A new session per call keeps this usable from the upload thread pool, since
+    `requests.Session` is not thread-safe.
     """
     session = requests.Session()
     retries = Retry(
@@ -139,8 +147,9 @@ def _download_from_cdn_and_upload_to_lfs_volume(
         print(
             f"LFS: uploading {src_url} -> {upload_method} {upload_href} ({size} bytes)"
         )
+        session = _new_retrying_session()
         with open(tmp_path, "rb") as f:
-            resp = requests.request(
+            resp = session.request(
                 upload_method.upper(),
                 upload_href,
                 data=f,
@@ -164,7 +173,8 @@ def _github_lfs_verify_upload(
     oid, size = source
     verify_href, method, headers = dest
     payload = {"oid": oid, "size": size}
-    r = requests.request(
+    session = _new_retrying_session()
+    r = session.request(
         method, verify_href, json=payload, headers=headers, timeout=timeout
     )
     if r.status_code not in (200, 201, 204):

--- a/cronjobs/src/commands/_git_export_lfs.py
+++ b/cronjobs/src/commands/_git_export_lfs.py
@@ -341,6 +341,11 @@ def github_lfs_batch_upload_many(
     chunks = list(itertools.batched(objects, GITHUB_MAX_LFS_BATCH_SIZE))
     total_chunks = len(chunks)
 
+    # Objects that the server refused or did not report. Collected across all
+    # chunks so that a single bad object does not hide the others, and raised at
+    # the end: callers must not push pointers for objects missing from storage.
+    failures: list[str] = []
+
     # Single session for batch/verify calls (NOT reused for presigned PUTs/POSTs)
     for idx, chunk in enumerate(chunks, start=1):
         print(f"LFS: uploading chunk {idx}/{total_chunks} ({len(chunk)} objects)")
@@ -364,14 +369,16 @@ def github_lfs_batch_upload_many(
         to_verify: list[tuple[tuple[str, int], tuple[str, str, dict[str, str]]]] = []
         for oid, size, url in chunk:
             api_obj = api_objs_by_oid.get(oid)
-            if not api_obj:  # pragma: no cover
-                print(
-                    f"LFS: warning: server omitted oid {oid} in batch response; skipping"
-                )
+            if not api_obj:
+                print(f"LFS: server omitted oid {oid} in batch response")
+                failures.append(f"{oid} ({url}): omitted from batch response")
                 continue
             if err := api_obj.get("error"):
                 print(
                     f"LFS: upload error for {oid}: {err.get('code')} {err.get('message')}"
+                )
+                failures.append(
+                    f"{oid} ({url}): {err.get('code')} {err.get('message')}"
                 )
                 continue
             act = api_obj.get("actions") or {}
@@ -416,3 +423,13 @@ def github_lfs_batch_upload_many(
             f"LFS: {len(to_upload)} uploaded and {len(to_verify)} verified in chunk {idx}/{total_chunks}"
         )
         time.sleep(SLOW_DOWN_SECONDS)  # avoid hitting rate limits
+
+    if failures:
+        # Raising here aborts the run before the caller pushes the commits that
+        # reference these objects. Committing pointers for objects that are not
+        # in LFS storage is unrecoverable: the next run reads the pointer back
+        # from the tree, considers the attachment unchanged, and never retries.
+        raise RuntimeError(
+            f"LFS: {len(failures)} object(s) could not be uploaded:\n - "
+            + "\n - ".join(failures)
+        )

--- a/cronjobs/src/commands/_git_export_lfs.py
+++ b/cronjobs/src/commands/_git_export_lfs.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 import jwt
 import requests
@@ -335,6 +335,29 @@ def github_lfs_validate_credentials(
     return authz
 
 
+def _run_in_parallel(
+    func: Callable[..., None],
+    args_list: Iterable[tuple[Any, ...]],
+    max_workers: int,
+) -> None:
+    """
+    Call `func(*args)` for each entry in parallel, propagating the first error.
+
+    Tasks that have not started yet are cancelled, so a failing chunk stops
+    quickly instead of transferring everything it had already queued.
+    """
+    args_list = list(args_list)
+    if not args_list:
+        return
+    pool = ThreadPoolExecutor(max_workers=max_workers)
+    try:
+        futures = [pool.submit(func, *args) for args in args_list]
+        for f in as_completed(futures):
+            f.result()  # propagate exceptions
+    finally:
+        pool.shutdown(wait=True, cancel_futures=True)
+
+
 def github_lfs_batch_upload_many(
     objects: Iterable[tuple[str, int, str]],  # (sha256_hex, size, source_url),
     repo_owner: str,
@@ -410,29 +433,19 @@ def github_lfs_batch_upload_many(
             else:
                 print(f"LFS: no verify action for {oid}, skipping verify.")
 
-        # Parallel uploads
-        if to_upload:
-            with ThreadPoolExecutor(max_workers=max_parallel_requests) as pool:
-                futures = [
-                    pool.submit(_download_from_cdn_and_upload_to_lfs_volume, src, dest)
-                    for (src, dest) in to_upload
-                ]
-                for f in as_completed(futures):
-                    f.result()  # propagate exceptions
-
-        # Parallel verifications
-        with ThreadPoolExecutor(max_workers=max_parallel_requests) as pool:
-            futures = [
-                pool.submit(_github_lfs_verify_upload, src, dest)
-                for (src, dest) in to_verify
-            ]
-            for f in as_completed(futures):
-                f.result()  # propagate exceptions
+        # Parallel uploads, then parallel verifications.
+        _run_in_parallel(
+            _download_from_cdn_and_upload_to_lfs_volume,
+            to_upload,
+            max_parallel_requests,
+        )
+        _run_in_parallel(_github_lfs_verify_upload, to_verify, max_parallel_requests)
 
         print(
             f"LFS: {len(to_upload)} uploaded and {len(to_verify)} verified in chunk {idx}/{total_chunks}"
         )
-        time.sleep(SLOW_DOWN_SECONDS)  # avoid hitting rate limits
+        if idx < total_chunks:
+            time.sleep(SLOW_DOWN_SECONDS)  # avoid hitting rate limits
 
     if failures:
         # Raising here aborts the run before the caller pushes the commits that

--- a/cronjobs/tests/commands/test_git_export_git_lfs.py
+++ b/cronjobs/tests/commands/test_git_export_git_lfs.py
@@ -430,7 +430,7 @@ def test_batch_upload_already_present_and_no_verify(capsys):
 
 
 @responses.activate
-def test_batch_upload_handles_error_objects(capsys):
+def test_batch_upload_raises_on_error_objects(capsys):
     o = ("d" * 64, 5, "https://cdn.example.com/d")
     batch_objects = [
         {
@@ -446,18 +446,74 @@ def test_batch_upload_handles_error_objects(capsys):
         content_type="application/vnd.git-lfs+json",
     )
 
-    github_lfs_batch_upload_many(
-        [o],
-        repo_owner="foo",
-        repo_name="bar",
-        auth_header="Bearer TOKEN",
-    )
+    # The object was refused by the server: the caller must not push a pointer
+    # for it, so the whole run has to fail.
+    with pytest.raises(RuntimeError, match="1 object\\(s\\) could not be uploaded"):
+        github_lfs_batch_upload_many(
+            [o],
+            repo_owner="foo",
+            repo_name="bar",
+            auth_header="Bearer TOKEN",
+        )
 
     assert len(responses.calls) == 1  # only batch
     out = capsys.readouterr().out
     assert "upload error for" in out
     assert "422" in out
     assert "unprocessable" in out
+
+
+@responses.activate
+def test_batch_upload_raises_when_server_omits_object(capsys):
+    o = ("e" * 64, 5, "https://cdn.example.com/e")
+    responses.add(
+        responses.POST,
+        "https://github.com/foo/bar.git/info/lfs/objects/batch",
+        status=200,
+        # Server answers without the object we asked for.
+        json={"objects": []},
+        content_type="application/vnd.git-lfs+json",
+    )
+
+    with pytest.raises(RuntimeError, match="1 object\\(s\\) could not be uploaded"):
+        github_lfs_batch_upload_many(
+            [o],
+            repo_owner="foo",
+            repo_name="bar",
+            auth_header="Bearer TOKEN",
+        )
+
+    out = capsys.readouterr().out
+    assert f"server omitted oid {o[0]}" in out
+
+
+@responses.activate
+def test_batch_upload_reports_every_failed_object():
+    objects = [(c * 64, 5, f"https://cdn.example.com/{c}") for c in "fgh"]
+    responses.add(
+        responses.POST,
+        "https://github.com/foo/bar.git/info/lfs/objects/batch",
+        status=200,
+        json={
+            "objects": [
+                {"oid": oid, "error": {"code": 422, "message": "nope"}}
+                for oid, _size, _url in objects
+            ]
+        },
+        content_type="application/vnd.git-lfs+json",
+    )
+
+    # One bad object must not mask the others.
+    with pytest.raises(RuntimeError) as exc_info:
+        github_lfs_batch_upload_many(
+            objects,
+            repo_owner="foo",
+            repo_name="bar",
+            auth_header="Bearer TOKEN",
+        )
+
+    for oid, _size, _url in objects:
+        assert oid in str(exc_info.value)
 
 
 @responses.activate

--- a/cronjobs/tests/commands/test_git_export_git_lfs.py
+++ b/cronjobs/tests/commands/test_git_export_git_lfs.py
@@ -11,6 +11,7 @@ from commands._git_export_lfs import (
     _download_from_cdn_and_upload_to_lfs_volume,
     _github_lfs_verify_upload,
     _new_retrying_session,
+    _run_in_parallel,
     github_lfs_batch_request,
 )
 from commands.git_export import (
@@ -179,6 +180,49 @@ def test_app_id_token_flow_failing(mock_jwt, temp_key):
             github_app_id=12345,
             github_app_private_key_path=temp_key,
         )
+
+
+def test_run_in_parallel_cancels_pending_tasks_on_error():
+    executed = []
+
+    def task(index):
+        if index == 0:
+            raise ValueError("boom")
+        executed.append(index)
+
+    # Single worker, so the tasks queued behind the failing one can be cancelled.
+    with pytest.raises(ValueError, match="boom"):
+        _run_in_parallel(task, [(i,) for i in range(6)], max_workers=1)
+
+    assert len(executed) < 5
+
+
+def test_run_in_parallel_without_any_task():
+    _run_in_parallel(mock.Mock(side_effect=AssertionError), [], max_workers=2)
+
+
+@responses.activate
+def test_batch_upload_does_not_slow_down_after_last_chunk():
+    objects = [(c * 64, 5, f"https://cdn.example.com/{c}") for c in "ab"]
+    responses.add(
+        responses.POST,
+        "https://github.com/foo/bar.git/info/lfs/objects/batch",
+        status=200,
+        json={"objects": [{"oid": oid, "actions": {}} for oid, _s, _u in objects]},
+        content_type="application/vnd.git-lfs+json",
+    )
+
+    with mock.patch.object(commands._git_export_lfs, "GITHUB_MAX_LFS_BATCH_SIZE", 1):
+        with mock.patch.object(commands._git_export_lfs.time, "sleep") as mock_sleep:
+            github_lfs_batch_upload_many(
+                objects,
+                repo_owner="foo",
+                repo_name="bar",
+                auth_header="Bearer TOKEN",
+            )
+
+    # Two chunks, one pause between them, none after the last.
+    assert mock_sleep.call_count == 1
 
 
 def test_retrying_session_retries_transient_failures():

--- a/cronjobs/tests/commands/test_git_export_git_lfs.py
+++ b/cronjobs/tests/commands/test_git_export_git_lfs.py
@@ -10,6 +10,7 @@ import responses
 from commands._git_export_lfs import (
     _download_from_cdn_and_upload_to_lfs_volume,
     _github_lfs_verify_upload,
+    _new_retrying_session,
     github_lfs_batch_request,
 )
 from commands.git_export import (
@@ -178,6 +179,47 @@ def test_app_id_token_flow_failing(mock_jwt, temp_key):
             github_app_id=12345,
             github_app_private_key_path=temp_key,
         )
+
+
+def test_retrying_session_retries_transient_failures():
+    session = _new_retrying_session()
+    retries = session.get_adapter("https://example.com").max_retries
+
+    assert retries.total == commands._git_export_lfs.HTTP_RETRY_MAX_COUNT
+    # Transient statuses that must not abort a whole export run.
+    for status in (500, 502, 503, 504, 429):
+        assert status in retries.status_forcelist
+    # Uploads and verifications are POST/PUT.
+    assert {"POST", "PUT"} <= set(retries.allowed_methods)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        # Every network call of the export goes through a retrying session:
+        # a single transient error must not discard the run's whole work.
+        lambda: commands._git_export_lfs.fetch_and_hash("https://cdn.example.com/x"),
+        lambda: _download_from_cdn_and_upload_to_lfs_volume(
+            ("a" * 64, 1, "https://cdn.example.com/x"),
+            ("https://lfs.example.com/up", "PUT", {}),
+        ),
+        lambda: _github_lfs_verify_upload(
+            ("a" * 64, 1), ("https://lfs.example.com/verify", "POST", {})
+        ),
+    ],
+)
+def test_transfers_use_a_retrying_session(call):
+    with mock.patch.object(
+        commands._git_export_lfs, "_new_retrying_session"
+    ) as mock_session:
+        # Bail out right after the session is built.
+        mock_session.return_value.get.side_effect = RuntimeError("stop")
+        mock_session.return_value.request.side_effect = RuntimeError("stop")
+
+        with pytest.raises(RuntimeError, match="stop"):
+            call()
+
+    assert mock_session.called
 
 
 @responses.activate


### PR DESCRIPTION
3 issues fixes:

- some LFS upload errors could be swallowed and LFS pointer published anyway
- some requests of LFS upload code were not retried
- we now cancel all uploading tasks if one fails (since final commit won't happen anyway)

Commits are trivial and come with tests that fail on main. Issues were found and fixed by Claude Code