### PR TITLE
git-export: prune empty folders recursively

### DIFF
--- a/cronjobs/src/commands/_git_export_git_tools.py
+++ b/cronjobs/src/commands/_git_export_git_tools.py
@@ -270,7 +270,12 @@ def tree_upsert_blobs(
                     except KeyError:
                         pass
                 child_oid = merge(val, existing_subtree)
-                builder.insert(name, child_oid, GIT_FILEMODE_TREE)
+                if len(cast(pygit2.Tree, repo[child_oid])) == 0:
+                    # Drop the folder entry instead of recording an empty tree.
+                    if base is not None and name in base:
+                        builder.remove(name)
+                else:
+                    builder.insert(name, child_oid, GIT_FILEMODE_TREE)
             else:
                 # Leaf file blob.
                 builder.insert(name, val, GIT_FILEMODE_BLOB)

--- a/cronjobs/tests/commands/test_git_export_git_tools.py
+++ b/cronjobs/tests/commands/test_git_export_git_tools.py
@@ -1,4 +1,5 @@
 import time
+from typing import cast
 from unittest import mock
 
 import pygit2
@@ -65,6 +66,33 @@ size 42
         == "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"  # pragma: allowlist secret
     )
     assert size == 42
+
+
+def test_tree_upsert_blobs_prunes_emptied_folders(tmp_repo):
+    repo = tmp_repo
+    base_tree = repo.revparse_single("main").tree
+    # "a/c/d.json" is the only blob of "a/c".
+    tree_oid = tree_upsert_blobs(repo, [("a/c/d.json", None)], base_tree=base_tree)
+
+    tree = repo[tree_oid]
+    subtree = cast(pygit2.Tree, tree)["a"]
+    assert "c" not in repo[subtree.id]
+    assert "b.txt" in repo[subtree.id]
+
+
+def test_tree_upsert_blobs_prunes_nested_emptied_folders(tmp_repo):
+    repo = tmp_repo
+    base_tree = repo.revparse_single("main").tree
+    tree_oid = tree_upsert_blobs(
+        repo,
+        [("a/b.txt", None), ("a/c/d.json", None)],
+        base_tree=base_tree,
+    )
+
+    # "a" folder now goes away
+    tree = cast(pygit2.Tree, repo[tree_oid])
+    assert "a" not in tree
+    assert "root.txt" in tree
 
 
 def test_iter_tree_single_file(tmp_repo):


### PR DESCRIPTION
Folder with no entries is invalid and `git fsck` reports it.

When we do `tree_upsert_blobs(repo, [("a/c/d.json", None)])`, we look if `a/c/` has any other entry otherwise we delete it