### PR TITLE
git-export: Renew LFS access tokens between chunk uploads

### DIFF
--- a/cronjobs/src/commands/_git_export_lfs.py
+++ b/cronjobs/src/commands/_git_export_lfs.py
@@ -1,11 +1,12 @@
 import base64
+import datetime
 import hashlib
 import itertools
 import os
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 import jwt
 import requests
@@ -29,6 +30,9 @@ SLOW_DOWN_SECONDS = config("SLOW_DOWN_SECONDS", default=3, cast=int)
 
 
 GITHUB_MAX_LFS_BATCH_SIZE = config("GITHUB_MAX_LFS_BATCH_SIZE", default=100, cast=int)
+GITHUB_TOKEN_RENEW_MARGIN_SECONDS = config(
+    "GITHUB_TOKEN_RENEW_MARGIN_SECONDS", default=300, cast=int
+)
 
 
 def fetch_and_hash(url: str, dest_file: str | None = None) -> tuple[str, int]:
@@ -234,6 +238,52 @@ def _mint_installation_access_token(
     return token, expires_at
 
 
+class GithubInstallationAuthHeader:
+    """
+    Callable returning a valid LFS `Authorization` header for a GitHub App,
+    that will mint a new installation access token when called.
+
+    Access tokens are only valid for one hour, and LFS can be slow.
+    Since we don't retry requests on `401` responses, we must renew it
+    before it expires.
+    """
+
+    def __init__(
+        self, app_id: str, private_key_path: str, repo_owner: str, repo_name: str
+    ) -> None:
+        self._app_id = app_id
+        self._private_key_path = private_key_path
+        self._repo_owner = repo_owner
+        self._repo_name = repo_name
+        self._header: str | None = None
+        self._expires_at = 0.0
+        self.token: str | None = None
+
+    def __call__(self) -> str:
+        will_expire_soon = (
+            time.time() >= self._expires_at - GITHUB_TOKEN_RENEW_MARGIN_SECONDS
+        )
+        if self._header is None or will_expire_soon:
+            # private key -> JWT -> installation ID -> installation token
+            # See https://docs.github.com/en/rest/reference/apps#authentication
+            jwt_token = _create_app_jwt(self._app_id, self._private_key_path)
+            installation_id = _resolve_installation_id(
+                jwt_token, self._repo_owner, self._repo_name
+            )
+            self.token, expires_at = _mint_installation_access_token(
+                jwt_token, installation_id
+            )
+            self._expires_at = datetime.datetime.fromisoformat(expires_at).timestamp()
+            # For LFS, use Basic with username 'x-access-token' and the
+            # installation token as the password.
+            self._header = _base64_auth_header("x-access-token", self.token)
+            print(
+                f"Issued installation access token (installation_id={installation_id}) expiring at {expires_at}"
+            )
+
+        return self._header
+
+
 def _verify_personal_token(username: str, token: str) -> dict[str, Any]:
     """
     Verifies that the personal access token is valid by fetching the user info.
@@ -278,43 +328,48 @@ def github_lfs_validate_credentials(
     github_app_id: str | int | None = None,
     github_app_private_key_path: str | None = None,
     timeout: float | tuple[float, float] = HTTP_TIMEOUT_BATCH_SECONDS,
-) -> str:
+) -> Callable[[], str]:
     """
     Test GitHub LFS credentials by making a dummy batch request.
+
+    Return a callable that yields the `Authorization` header to use. For a
+    GitHub App it renews the short-lived installation access token on demand.
     """
+    auth_header_provider: Callable[[], str]
+
     if github_username and github_token:
         if not github_token.startswith("github_pat_"):
             print(
                 "Warning: It looks like the provided GitHub token is not a PAT (personal access token)."
             )
         authz = _base64_auth_header(github_username, github_token)
+        # Personal access token does not expire, lambda returns a constant.
+        auth_header_provider = lambda: authz  # noqa: E731
         user_data = _verify_personal_token(github_username, github_token)
         print(
             f"Authenticated as GitHub user: {user_data.get('login')} (id={user_data.get('id')})"
         )
 
     elif github_app_id and github_app_private_key_path:
-        # For LFS, use Basic with username 'x-access-token' and the installation token as the password.
-        # private key -> JWT -> installation ID -> installation token -> Basic auth with token
-        # See https://docs.github.com/en/rest/reference/apps#authentication
-        jwt_token = _create_app_jwt(str(github_app_id), github_app_private_key_path)
-        installation_id = _resolve_installation_id(jwt_token, repo_owner, repo_name)
-        installation_token, expires_at = _mint_installation_access_token(
-            jwt_token, installation_id
+        installation = GithubInstallationAuthHeader(
+            str(github_app_id), github_app_private_key_path, repo_owner, repo_name
         )
-        print(
-            f"Issued installation access token (installation_id={installation_id}) expiring at {expires_at}"
-        )
+        installation()  # Mint a first token.
         repo_info = _verify_installation_token(
-            installation_token, repo_owner, repo_name
+            str(installation.token), repo_owner, repo_name
         )
         print(
             f"Installation token can access repo: {repo_info.get('full_name')} (id={repo_info.get('id')})"
         )
-        authz = _base64_auth_header("x-access-token", installation_token)
+        auth_header_provider = installation
+    else:
+        raise ValueError(
+            "No GitHub credentials configured: set GITHUB_USERNAME and GITHUB_TOKEN, "
+            "or GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY_PATH."
+        )
 
     github_lfs_batch_request(
-        auth_header=authz,
+        auth_header=auth_header_provider(),
         objects=[{"oid": "a" * 64, "size": 42}],  # dummy object
         operation="upload",
         repo_owner=repo_owner,
@@ -322,14 +377,14 @@ def github_lfs_validate_credentials(
         timeout=timeout,
     )
 
-    return authz
+    return auth_header_provider
 
 
 def github_lfs_batch_upload_many(
     objects: Iterable[tuple[str, int, str]],  # (sha256_hex, size, source_url),
     repo_owner: str,
     repo_name: str,
-    auth_header: str,
+    auth_header_provider: Callable[[], str],
     max_parallel_requests: int = MAX_PARALLEL_REQUESTS,
 ) -> None:
     """
@@ -337,6 +392,8 @@ def github_lfs_batch_upload_many(
     PUTs missing objects to the presigned destinations, and POSTs verify if provided.
 
     objects: iterable of (oid_hex:str, size:int, src_url:str)
+    auth_header: header value, or a callable returning it. Pass a callable when
+      the credentials expire, so that each batch gets a fresh header.
     """
     chunks = list(itertools.batched(objects, GITHUB_MAX_LFS_BATCH_SIZE))
     total_chunks = len(chunks)
@@ -346,7 +403,7 @@ def github_lfs_batch_upload_many(
         print(f"LFS: uploading chunk {idx}/{total_chunks} ({len(chunk)} objects)")
 
         batch_resp = github_lfs_batch_request(
-            auth_header=auth_header,
+            auth_header=auth_header_provider(),
             objects=[{"oid": oid, "size": size} for (oid, size, _url) in chunk],
             operation="upload",
             repo_owner=repo_owner,

--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -114,7 +114,7 @@ def git_export() -> None:
     print(
         f"Testing GitHub Token for {GITHUB_USERNAME or GITHUB_APP_ID} on {REPO_OWNER}/{REPO_NAME}..."
     )
-    auth_header = github_lfs_validate_credentials(
+    auth_header_provider = github_lfs_validate_credentials(
         repo_owner=REPO_OWNER,
         repo_name=REPO_NAME,
         github_username=GITHUB_USERNAME,
@@ -160,7 +160,7 @@ def git_export() -> None:
             objects=changed_attachments,
             repo_owner=REPO_OWNER,
             repo_name=REPO_NAME,
-            auth_header=auth_header,
+            auth_header_provider=auth_header_provider,
         )
 
         changed_tags = [f"+{tag}" for tag in created_tags] + [

--- a/cronjobs/tests/commands/test_git_export.py
+++ b/cronjobs/tests/commands/test_git_export.py
@@ -787,7 +787,7 @@ def test_repo_sync_stores_attachments_as_lfs_pointers(
     assert "lfs" in rid2.decode()
 
     (_, kwargs) = mock_github_lfs.call_args_list[0]
-    assert kwargs["auth_header"] == "Bearer TOKEN"
+    assert kwargs["auth_header_provider"] == "Bearer TOKEN"
     assert kwargs["repo_owner"] == git_export.REPO_OWNER
     assert kwargs["repo_name"] == git_export.REPO_NAME
     objs = [(size, url) for hash, size, url in kwargs["objects"]]

--- a/cronjobs/tests/commands/test_git_export_git_lfs.py
+++ b/cronjobs/tests/commands/test_git_export_git_lfs.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 from unittest import mock
 
@@ -8,6 +9,7 @@ import pytest
 import requests
 import responses
 from commands._git_export_lfs import (
+    GithubInstallationAuthHeader,
     _download_from_cdn_and_upload_to_lfs_volume,
     _github_lfs_verify_upload,
     github_lfs_batch_request,
@@ -178,6 +180,114 @@ def test_app_id_token_flow_failing(mock_jwt, temp_key):
             github_app_id=12345,
             github_app_private_key_path=temp_key,
         )
+
+
+@responses.activate
+def test_installation_token_is_reused_until_it_expires(mock_jwt, temp_key):
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/leplatrem/remote-settings-data/installation",
+        json={"id": 42},
+        status=200,
+    )
+    expires_at = (
+        datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=1)
+    ).isoformat()
+    responses.add(
+        responses.POST,
+        "https://api.github.com/app/installations/42/access_tokens",
+        json={"token": "TOKEN", "expires_at": expires_at},
+        status=201,
+    )
+
+    provider = GithubInstallationAuthHeader(
+        "12345", temp_key, "leplatrem", "remote-settings-data"
+    )
+
+    assert provider() == provider()
+    mint_calls = [
+        c for c in responses.calls if c.request.url.endswith("/access_tokens")
+    ]
+    assert len(mint_calls) == 1
+
+
+@responses.activate
+def test_installation_token_is_renewed_before_expiry(mock_jwt, temp_key):
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/leplatrem/remote-settings-data/installation",
+        json={"id": 42},
+        status=200,
+    )
+    # Already within the renewal margin: every call has to mint a new token.
+    expires_at = (
+        datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=30)
+    ).isoformat()
+    responses.add(
+        responses.POST,
+        "https://api.github.com/app/installations/42/access_tokens",
+        json={"token": "TOKEN", "expires_at": expires_at},
+        status=201,
+    )
+
+    provider = GithubInstallationAuthHeader(
+        "12345", temp_key, "leplatrem", "remote-settings-data"
+    )
+    provider()
+    provider()
+
+    mint_calls = [
+        c for c in responses.calls if c.request.url.endswith("/access_tokens")
+    ]
+    assert len(mint_calls) == 2
+
+
+@responses.activate
+def test_batch_upload_renews_credentials_between_chunks(mock_jwt, temp_key):
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/foo/bar/installation",
+        json={"id": 42},
+        status=200,
+    )
+    # Already within the renewal margin: every call has to mint a new token.
+    expires_at = (
+        datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=30)
+    ).isoformat()
+    responses.add(
+        responses.POST,
+        "https://api.github.com/app/installations/42/access_tokens",
+        json={"token": "TOKEN", "expires_at": expires_at},
+        status=201,
+    )
+    provider = GithubInstallationAuthHeader("12345", temp_key, "foo", "bar")
+    objects = [(c * 64, 5, f"https://cdn.example.com/{c}") for c in "ab"]
+
+    # One batch response per chunk, with objects already present on the server.
+    for oid, size, _url in objects:
+        responses.add(
+            responses.POST,
+            "https://github.com/foo/bar.git/info/lfs/objects/batch",
+            status=200,
+            json={"objects": [{"oid": oid, "size": size, "actions": {}}]},
+            content_type="application/vnd.git-lfs+json",
+        )
+
+    with mock.patch.object(commands._git_export_lfs, "GITHUB_MAX_LFS_BATCH_SIZE", 1):
+        github_lfs_batch_upload_many(
+            objects,
+            repo_owner="foo",
+            repo_name="bar",
+            auth_header_provider=provider,
+        )
+
+    # Two chunks, so two batch calls, each with a freshly minted token.
+    batch_calls = [c for c in responses.calls if c.request.url.endswith("/batch")]
+    mint_calls = [
+        c for c in responses.calls if c.request.url.endswith("/access_tokens")
+    ]
+    assert len(batch_calls) == 2
+    assert len(mint_calls) == 2
 
 
 @responses.activate
@@ -419,7 +529,7 @@ def test_batch_upload_already_present_and_no_verify(capsys):
         [obj],
         repo_owner="foo",
         repo_name="bar",
-        auth_header="Bearer TOKEN",
+        auth_header_provider=lambda: "Bearer TOKEN",
     )
 
     # only the batch call
@@ -450,7 +560,7 @@ def test_batch_upload_handles_error_objects(capsys):
         [o],
         repo_owner="foo",
         repo_name="bar",
-        auth_header="Bearer TOKEN",
+        auth_header_provider=lambda: "Bearer TOKEN",
     )
 
     assert len(responses.calls) == 1  # only batch
@@ -529,7 +639,7 @@ def test_batch_upload_and_verify():
         [o1, o2],
         repo_owner="foo",
         repo_name="bar",
-        auth_header="Bearer TOKEN",
+        auth_header_provider=lambda: "Bearer TOKEN",
     )
 
     calls = responses.calls


### PR DESCRIPTION
If LFS upload lasts more than 1H, we get 401s and don't retry