### PR TITLE
Bug 2069898: prevent editors to empty the destination collection without approval

### DIFF
--- a/kinto-remote-settings/src/kinto_remote_settings/signer/listeners.py
+++ b/kinto-remote-settings/src/kinto_remote_settings/signer/listeners.py
@@ -9,7 +9,7 @@ from kinto.core.storage.exceptions import ObjectNotFoundError
 from kinto.core.utils import instance_uri
 from pyramid import httpexceptions
 from pyramid.interfaces import IAuthorizationPolicy
-from pyramid.settings import asbool
+from pyramid.settings import asbool, aslist
 
 from . import events as signer_events
 from .updater import TRACKING_FIELDS, LocalUpdater
@@ -700,6 +700,14 @@ def cleanup_preview_destination(event: Any, resources: dict[str, Any]) -> None:
     permission = event.request.registry.permission
     settings = event.request.registry.settings
 
+    # Editors and reviewers are granted `write` on the source collection to manage its
+    # records. Since deleting a source collection empties and signs its destination
+    # without any review, offboarding a collection is restricted to administrators.
+    administrators = set(aslist(settings.get("bucket_write_principals", ""))) | set(
+        aslist(settings.get("collection_write_principals", ""))
+    )
+    is_administrator = bool(administrators & set(event.request.prefixed_principals))
+
     for impacted in event.impacted_objects:
         old_collection = impacted["old"]
 
@@ -715,6 +723,14 @@ def cleanup_preview_destination(event: Any, resources: dict[str, Any]) -> None:
         )
         if resource is None:
             continue
+
+        if not is_administrator:
+            raise_forbidden(
+                message=(
+                    "Cannot delete the source collection: offboarding a collection "
+                    "requires administrator access."
+                )
+            )
 
         # Delete groups (without tombstones if soft delete)
         should_hard_delete = asbool(

--- a/kinto-remote-settings/tests/signer/test_plugin_setup.py
+++ b/kinto-remote-settings/tests/signer/test_plugin_setup.py
@@ -571,6 +571,9 @@ class SourceCollectionSoftDeletion(BaseWebTest, PatchAutographMixin, unittest.Te
         resp = self.app.get("/", headers=self.other_headers)
         self.other_userid = resp.json["user"]["id"]
 
+        # Deleting a source collection is reserved to administrators.
+        self.app.app.registry.settings["bucket_write_principals"] = self.userid
+
         self.app.put_json("/buckets/stage", headers=self.headers)
 
         self.app.put_json(
@@ -687,6 +690,9 @@ class SourceCollectionHardDeletion(BaseWebTest, PatchAutographMixin, unittest.Te
         self.other_headers = get_user_headers("Sam:Wan Heilss")
         resp = self.app.get("/", headers=self.other_headers)
         self.other_userid = resp.json["user"]["id"]
+
+        # Deleting a source collection is reserved to administrators.
+        self.app.app.registry.settings["bucket_write_principals"] = self.userid
 
         self.app.put_json("/buckets/stage", headers=self.headers)
 

--- a/kinto-remote-settings/tests/signer/test_signoff_flow.py
+++ b/kinto-remote-settings/tests/signer/test_signoff_flow.py
@@ -1142,6 +1142,9 @@ class CollectionDelete(SignoffWebTest, unittest.TestCase):
     def setUp(self):
         super(CollectionDelete, self).setUp()
 
+        # Deleting a source collection is reserved to administrators.
+        self.app.app.registry.settings["bucket_write_principals"] = self.userid
+
         self.app.put(
             self.source_bucket + "/collections/no-preview", headers=self.headers
         )
@@ -1162,6 +1165,11 @@ class CollectionDelete(SignoffWebTest, unittest.TestCase):
             headers=self.headers,
             status=403,
         )
+
+    def test_cannot_delete_source_collection_without_admin_rights(self):
+        # ``other_headers`` has ``write`` on the source bucket, like editors and
+        # reviewers do on the source collection, but is not an administrator.
+        self.app.delete(self.source_collection, headers=self.other_headers, status=403)
 
     def test_can_delete_preview_if_source_is_deleted(self):
         self.app.delete(self.source_collection, headers=self.headers)


### PR DESCRIPTION
Nothing challenging our security model, but still good to fix.

See https://bugzilla.mozilla.org/show_bug.cgi?id=2069898

Note: This will prevent people to delete collections themselves on DEV. We could add a condition on the `hard_delete_destination_on_source_deletion` setting in case we would avoid that. I wasn't too sure whether it's useful or not, since AFAIK people never delete stuff on dev 🤣 
