### PR TITLE
git-export: Remove manipulation of tags

### DIFF
--- a/cronjobs/src/commands/_git_export_git_tools.py
+++ b/cronjobs/src/commands/_git_export_git_tools.py
@@ -9,8 +9,6 @@ from pygit2 import (
 )
 from pygit2.enums import FetchPrune, SortMode
 
-from . import ts2dt
-
 
 REMOTE_NAME = "origin"
 
@@ -33,7 +31,7 @@ def clone_or_fetch(
                 f"Remote URL {remote.url} of work dir {repo_path} does not match {repo_url}"
             )
         if not repo.raw_listall_references():
-            print("No branches or tags found in the repository.")
+            print("No branches found in the repository.")
         else:
             if not repo.head_is_unborn:
                 print("Head was at", repo.head.target)
@@ -44,13 +42,11 @@ def clone_or_fetch(
         print(f"Clone {repo_url} into {repo_path}...")
         pygit2.clone_repository(repo_url, repo_path, callbacks=callbacks)
         repo = pygit2.Repository(repo_path)
-    reset_repo(repo, callbacks=callbacks)
+    reset_repo(repo)
     return repo
 
 
-def reset_repo(
-    repo: pygit2.Repository, callbacks: pygit2.RemoteCallbacks | None
-) -> None:
+def reset_repo(repo: pygit2.Repository) -> None:
     print("Reset local content to remote content...")
     # If the repo is freshly cloned, the remotes branches do not exist locally. Create them.
     # If the repo was cloned from previous run, reset the local branches to the remote targets.
@@ -83,64 +79,23 @@ def reset_repo(
             print(f"Delete local branch {branch_name}")
             ref.delete()
 
-    # Delete local tags that are not on remote
-    origin = repo.remotes[REMOTE_NAME]
-    remote_tags = {
-        obj.name
-        for obj in origin.list_heads(callbacks=callbacks)
-        if obj.name and obj.name.startswith("refs/tags/") and not obj.local
-    }
-    for ref in repo.references:
-        if not ref.startswith("refs/tags/") or ref in remote_tags:
-            continue
-        print(f"Delete local tag {ref}")
-        repo.references.delete(ref)
-
 
 def push_mirror(
     repo: pygit2.Repository,
     branches: Iterable[str],
-    tags: Iterable[str],
     callbacks: pygit2.RemoteCallbacks,
 ) -> None:
     """
-    An equivalent of `git push --force --mirror` for branches + tags only.
+    An equivalent of `git push --force --mirror` for branches only.
     """
-    to_push = []
-    # 1) Force update all local branches
-    for b in sorted(branches):
-        to_push.append(f"+{b}:{b}")
-    # 2) Force update all local tags
-    to_delete = []
-    for t in sorted(tags):
-        deleting = t.startswith("-")
-        name = t[1:]
-        full = name if name.startswith("refs/tags/") else f"refs/tags/{name}"
-        if deleting:
-            to_delete.append(f":{full}")
-        else:
-            to_push.append(f"+{full}:{full}")
-
-    if not to_push and not to_delete:
+    if not branches:
         print("Everything up-to-date.")
         return
 
-    # First push the new content, and then delete old tags in a second push.
-    # We do that because if the remote times out or fails with tags deletion,
-    # at least the new content is pushed.
+    to_push = [f"{b}:{b.replace('+', '')}" for b in sorted(branches)]
     remote = repo.remotes[REMOTE_NAME]
-    if to_push:
-        print(f"Pushing to remote {remote.url}:\n - {'\n - '.join(to_push)}")
-        # This is the critical bit: non-fast-forward updates require the '+' force.
-        # The deletions use the ':refs/...'; '+' is ignored for deleted refspecs.
-        remote.push(to_push, callbacks=callbacks)
-    else:
-        print("No new commit or tag to push.")
-    if to_delete:
-        print(f"Deleting from remote {remote.url}:\n - {'\n - '.join(to_delete)}")
-        remote.push(to_delete, callbacks=callbacks)
-    else:
-        print("No tag to delete.")
+    print(f"Pushing to remote {remote.url}:\n - {'\n - '.join(to_push)}")
+    remote.push(to_push, callbacks=callbacks)
 
 
 def make_lfs_pointer(sha256_hex: str, size: int) -> bytes:
@@ -279,135 +234,58 @@ def tree_upsert_blobs(
     return merge(updates_trie, base_tree)
 
 
-def delete_old_tags(
-    repo: pygit2.Repository, max_age_days: int, min_tags_per_collection: int = 2
-) -> list[str]:
+def truncate_branch(repo: pygit2.Repository, branch: str, keep_days: int) -> bool:
     """
-    Delete old tags from the repository, keeping the most recent `min_tags_per_collection` tags for each collection.
+    Rewrite the specified branch to drop the commits older than `keep_days`.
 
-    Return the list of deleted tag names.
-    """
-    print(
-        f"Delete tags older than {max_age_days} days, keeping at least {min_tags_per_collection} per collection."
-    )
-    deleted_tags = []
-    now_ts = int(time.time() * 1000)
-
-    timestamp_tags = [
-        ref_name
-        for ref_name in repo.references
-        if ref_name.startswith("refs/tags/") and "/timestamps/" in ref_name
-    ]
-    group_by_collection: dict[str, list[tuple[str, int]]] = {}
-    for ref_name in sorted(timestamp_tags):
-        collection, timestamp = ref_name.rsplit("/", 1)
-        timestamp = int(timestamp)
-        group_by_collection.setdefault(collection, []).append((ref_name, timestamp))
-
-    # For each collection, we find all the tags that are older than
-    # threshold. We keep the most recent `min_tags_per_collection` old tags
-    # to make sure clients can catch up with synchronization.
-    # This logic helps us cover the situation described in mozilla/remote-settings#1109
-    # (several updates in a short period of time after a long inactivity).
-    for collection, tags in group_by_collection.items():
-        count_before = len(deleted_tags)
-        kept_count = 0
-        for ref_name, timestamp in reversed(tags):
-            age_days = (now_ts - timestamp) / (60 * 60 * 24 * 1000)
-            if age_days < max_age_days or kept_count < min_tags_per_collection:
-                kept_count += 1
-                continue
-
-            dt = ts2dt(timestamp).isoformat()
-            print(f"Deleting tag {ref_name} (timestamp: {dt})")
-            repo.references.delete(ref_name)
-            deleted_tags.append(ref_name)
-
-        print(
-            f"{len(deleted_tags) - count_before} tags to delete for {collection!r} collection"
-        )
-
-    print(f"{len(deleted_tags)} tags to delete in total")
-    return deleted_tags
-
-
-def truncate_branch(
-    repo: pygit2.Repository, branch: str, tags_deletion_threshold: int
-) -> None:
-    """
-    Rewrite the specified branch to start from the oldest tagged commit.
-
-    This removes all commits prior to the oldest tagged commit in the branch,
-    and force-updates the branch to point to the new tip.
-    This function is destructive and rewrites history.
+    This removes the oldest commits of the branch, and force-updates it to point
+    to the rewritten tip. This function is destructive and rewrites history.
+    Return whether the branch was rewritten.
 
     A branch like:
 
-    o--o--o--o--o--o(tag)--o(tag)--o(tag)
+    o--o--o--o--o--o--o
+    <- older -><- kept ->
 
     would be forced to become
 
-    o(tag)--o(tag)--o(tag)
+    o--o--o
+
+    The most recent commit is always kept, even if it is older than `keep_days`.
     """
-    branch_ref_name = "refs/heads/" + branch
-    branch_ref = repo.references[branch_ref_name]
+    branch_ref = repo.references.get("refs/heads/" + branch)
+    if branch_ref is None:  # pragma: no cover
+        raise ValueError(f"Branch {branch} does not exist.")
+
+    if keep_days < 0:
+        return False
+
     tip_oid = branch_ref.target
 
-    # Precompute set of commits with tags
-    commits_to_refs = {}
-    for ref_name in repo.references:
-        if not ref_name.startswith("refs/tags/") or "/timestamps/" not in ref_name:
-            continue
-        tag_ref = repo.references[ref_name]
-        target_oid = tag_ref.target
-        tag_obj = repo[target_oid]
-        obj = tag_obj.peel(pygit2.Commit)
-        assert isinstance(obj, pygit2.Commit), (
-            f"Tag {ref_name} does not point to a commit"
-        )
-        commits_to_refs[obj.id] = ref_name
+    # `commit_time` is in seconds since epoch.
+    cutoff = int(time.time()) - keep_days * 24 * 60 * 60
 
-    assert commits_to_refs, "No timestamps tags found in the repository."
+    # Walk commits from the tip towards roots: newest -> oldest.
+    kept: list[pygit2.Commit] = []
+    dropped = 0
+    truncating = False
+    for commit in repo.walk(tip_oid, SortMode.TOPOLOGICAL | SortMode.TIME):
+        if truncating or (kept and commit.commit_time < cutoff):
+            truncating = True
+            dropped += 1
+        else:
+            kept.append(commit)
 
-    # Walk commits from the tip towards roots: newest -> oldest
-    chain_commits: list[pygit2.Commit] = []
-    walker = repo.walk(tip_oid, SortMode.TOPOLOGICAL | SortMode.TIME)
-    to_delete_count = 0
-    past_tagged_region = False
-    for commit in walker:
-        if commit.id not in commits_to_refs:
-            assert len(chain_commits) > 0, (
-                f"Latest commit {commit.id} of branch {branch} is not tagged. Cannot truncate."
-            )
-            # Count all untagged commits below the oldest tagged commit.
-            past_tagged_region = True
-            to_delete_count += 1
-        elif not past_tagged_region:
-            chain_commits.append(commit)
+    if not dropped:
+        print(f"Branch {branch} has no commit older than {keep_days} days.")
+        return False
 
-    assert chain_commits, f"No tagged commit found in branch {branch}"
-
-    # Reverse to have oldest -> newest
-    chain_commits.reverse()
-    if len(chain_commits[0].parents) == 0:
-        print(
-            f"Branch {branch} already starts from a tagged commit ({str(chain_commits[0].id)[:7]}), nothing to do."
-        )
-        return
-
-    if to_delete_count < tags_deletion_threshold:
-        print(
-            f"Wait until more tags are deleted before truncating branch ({to_delete_count}/{tags_deletion_threshold})"
-        )
-        return
-
-    # Recreate the chain of commits to "rebuild" the branch.
-    print(
-        f"Rebuilding branch (from {len(chain_commits) + to_delete_count} commits to {len(chain_commits)})"
-    )
-    parents_list = []  # for the first in chain, parent list will be []
+    # Recreate the chain of commits to "rebuild" the branch, from oldest to newest.
+    kept.reverse()
+    print(f"Rebuilding {branch} (from {len(kept) + dropped} commits to {len(kept)})")
+    parents_list: list[pygit2.Oid] = []
     new_root = None
-    for commit in chain_commits:
+    for commit in kept:
         new_oid = repo.create_commit(
             None,  # no ref update
             commit.author,
@@ -418,14 +296,16 @@ def truncate_branch(
         )
         if new_root is None:
             new_root = new_oid
-        # Next commit will parent this one
+        # Next commit will parent this one.
         parents_list = [new_oid]
-        # Move the tags that pointed to the old commit into the new commit
-        tag_ref = commits_to_refs[commit.id]
-        repo.references.create(tag_ref, new_oid, force=True)
 
-    # Now force-move the branch to the new tip
+    # Now force-move the branch to the new tip.
     new_tip_oid = parents_list[0]
-    msg = f"Truncate {branch} at oldest tagged commit (root from {str(chain_commits[0].id)[:7]} to {str(new_root)[:7]}, tip from {str(tip_oid)[:7]} to {str(new_tip_oid)[:7]})"
+    msg = (
+        f"Truncate {branch} to the last {keep_days} days "
+        f"(root from {str(kept[0].id)[:7]} to {str(new_root)[:7]}, "
+        f"tip from {str(tip_oid)[:7]} to {str(new_tip_oid)[:7]})"
+    )
     branch_ref.set_target(new_tip_oid, msg)
     print(msg)
+    return True

--- a/cronjobs/src/commands/_git_export_git_tools.py
+++ b/cronjobs/src/commands/_git_export_git_tools.py
@@ -11,6 +11,8 @@ from pygit2.enums import FetchPrune, SortMode
 
 
 REMOTE_NAME = "origin"
+# Extra age tolerated before truncating, as a ratio of `keep_days`.
+TRUNCATE_MARGIN_RATIO = 0.1
 
 
 def clone_or_fetch(
@@ -252,6 +254,9 @@ def truncate_branch(repo: pygit2.Repository, branch: str, keep_days: int) -> boo
     o--o--o
 
     The most recent commit is always kept, even if it is older than `keep_days`.
+
+    Since rewriting is expensive, it only happens once the oldest commit exceeds
+    `keep_days` by `TRUNCATE_MARGIN_RATIO` (eg. 11 days when keeping 10 days).
     """
     branch_ref = repo.references.get("refs/heads/" + branch)
     if branch_ref is None:  # pragma: no cover
@@ -263,21 +268,33 @@ def truncate_branch(repo: pygit2.Repository, branch: str, keep_days: int) -> boo
     tip_oid = branch_ref.target
 
     # `commit_time` is in seconds since epoch.
-    cutoff = int(time.time()) - keep_days * 24 * 60 * 60
+    now = int(time.time())
+    cutoff = now - keep_days * 24 * 60 * 60
+    margin_days = keep_days * (1 + TRUNCATE_MARGIN_RATIO)
+    margin_cutoff = now - int(margin_days * 24 * 60 * 60)
 
     # Walk commits from the tip towards roots: newest -> oldest.
     kept: list[pygit2.Commit] = []
     dropped = 0
     truncating = False
+    beyond_margin = False
     for commit in repo.walk(tip_oid, SortMode.TOPOLOGICAL | SortMode.TIME):
         if truncating or (kept and commit.commit_time < cutoff):
             truncating = True
             dropped += 1
+            beyond_margin = beyond_margin or commit.commit_time < margin_cutoff
         else:
             kept.append(commit)
 
     if not dropped:
         print(f"Branch {branch} has no commit older than {keep_days} days.")
+        return False
+
+    if not beyond_margin:
+        print(
+            f"Branch {branch} has {dropped} commit(s) older than {keep_days} days, "
+            f"but none older than {margin_days:.0f} days."
+        )
         return False
 
     # Recreate the chain of commits to "rebuild" the branch, from oldest to newest.

--- a/cronjobs/src/commands/_git_export_git_tools.py
+++ b/cronjobs/src/commands/_git_export_git_tools.py
@@ -88,7 +88,8 @@ def push_mirror(
     callbacks: pygit2.RemoteCallbacks,
 ) -> None:
     """
-    An equivalent of `git push --force --mirror` for branches only.
+    An equivalent of `git push --mirror` for branches only.
+    Only branches with `+` prefix will be pushed forced.
     """
     if not branches:
         print("Everything up-to-date.")

--- a/cronjobs/src/commands/git_export.py
+++ b/cronjobs/src/commands/git_export.py
@@ -19,7 +19,6 @@ from pygit2 import (
 from . import ts2dt
 from ._git_export_git_tools import (
     clone_or_fetch,
-    delete_old_tags,
     list_lfs_pointers,
     make_lfs_pointer,
     push_mirror,
@@ -35,43 +34,41 @@ from ._git_export_lfs import (
 
 
 # Mandatory environment variables (default values)
-SERVER_URL = config("SERVER", default="http://localhost:8888/v1")
-GIT_AUTHOR = config("GIT_AUTHOR", default="User <user@example.com>")
-REPO_OWNER = config("REPO_OWNER", default="mozilla")
-REPO_NAME = config("REPO_NAME", default="remote-settings-data")
-SSH_PRIVKEY_PATH = os.path.expanduser(
+SERVER_URL: str = config("SERVER", default="http://localhost:8888/v1")
+GIT_AUTHOR: str = config("GIT_AUTHOR", default="User <user@example.com>")
+REPO_OWNER: str = config("REPO_OWNER", default="mozilla")
+REPO_NAME: str = config("REPO_NAME", default="remote-settings-data")
+SSH_PRIVKEY_PATH: str = os.path.expanduser(
     config("SSH_PRIVKEY_PATH", default="~/.ssh/id_ed25519")
 )
-SSH_KEY_PASSPHRASE = config("SSH_KEY_PASSPHRASE", default="")
+SSH_KEY_PASSPHRASE: str = config("SSH_KEY_PASSPHRASE", default="")
 
 # LFS GitHub authentication
 # Option A: Personal Access Token (PAT)
-GITHUB_USERNAME = config("GITHUB_USERNAME", default=None)
-GITHUB_TOKEN = config("GITHUB_TOKEN", default=None)
+GITHUB_USERNAME: str | None = config("GITHUB_USERNAME", default=None)
+GITHUB_TOKEN: str | None = config("GITHUB_TOKEN", default=None)
 # Option B: GitHub App authentication
-GITHUB_APP_ID = config("GITHUB_APP_ID", default=None)
-GITHUB_APP_PRIVATE_KEY_PATH = config("GITHUB_APP_PRIVATE_KEY_PATH", default=None)
+GITHUB_APP_ID: str | None = config("GITHUB_APP_ID", default=None)
+GITHUB_APP_PRIVATE_KEY_PATH: str | None = config(
+    "GITHUB_APP_PRIVATE_KEY_PATH", default=None
+)
 
 # Internal parameters
-WORK_DIR = config("WORK_DIR", default="/tmp/git-export.git")
-MAX_PARALLEL_REQUESTS = config("MAX_PARALLEL_REQUESTS", default=10, cast=int)
-LOG_LEVEL = config("LOG_LEVEL", default="INFO").upper()
-GIT_SSH_USERNAME = config("GIT_SSH_USERNAME", default="git")
-GIT_REMOTE_URL = config(
+WORK_DIR: str = config("WORK_DIR", default="/tmp/git-export.git")
+MAX_PARALLEL_REQUESTS: int = config("MAX_PARALLEL_REQUESTS", default=10, cast=int)
+LOG_LEVEL: str = config("LOG_LEVEL", default="INFO").upper()
+GIT_SSH_USERNAME: str = config("GIT_SSH_USERNAME", default="git")
+GIT_REMOTE_URL: str = config(
     "GIT_REMOTE_URL",
     default=f"{GIT_SSH_USERNAME}@github.com:{REPO_OWNER}/{REPO_NAME}.git",
 )
-SSH_PUBKEY_PATH = os.path.expanduser(
+SSH_PUBKEY_PATH: str = os.path.expanduser(
     config("SSH_PUBKEY_PATH", default=f"{SSH_PRIVKEY_PATH}.pub")
 )
-TAGS_MAX_AGE_DAYS = config("TAGS_MAX_AGE_DAYS", default=30, cast=int)
-MIN_TAGS_PER_COLLECTION_COUNT = config(
-    "MIN_TAGS_PER_COLLECTION_COUNT", default=3, cast=int
-)
-# We truncate and force push the common branch only every 50 publications (a few days).
-# This is to avoid excessive rewriting of history. Truncating is only needed to
-# garbage collect old LFS objects that are no longer referenced by any tag.
-TAGS_DELETION_THRESHOLD = config("TAGS_DELETION_THRESHOLD", default=50, cast=int)
+# The `common` branch carries the LFS pointers of the attachments. Truncating its
+# history will remove objects that are no longer referenced by any commit from
+# LFS storage.
+COMMON_BRANCH_KEEP_DAYS: int = config("COMMON_BRANCH_KEEP_DAYS", default=90, cast=int)
 
 _now = datetime.datetime.now(datetime.timezone.utc)
 
@@ -125,35 +122,21 @@ def git_export() -> None:
 
     repo = clone_or_fetch(GIT_REMOTE_URL, WORK_DIR, callbacks=callbacks)
     if not repo.raw_listall_references():
-        print("No branches or tags found in the repository.")
+        print("No branches found in the repository.")
     else:
         if not repo.head_is_unborn:
             print("Head is now at", repo.head.target)
 
     try:
-        changed_attachments, changed_branches, created_tags = asyncio.run(
-            repo_sync_content(repo)
-        )
+        changed_attachments, changed_branches = asyncio.run(repo_sync_content(repo))
 
-        # Tags are files on disk, and having too many tags slows down git operations.
-        # Delete old ones to keep the repository size reasonable.
-        deleted_tags = delete_old_tags(
-            repo,
-            max_age_days=TAGS_MAX_AGE_DAYS,
-            min_tags_per_collection=MIN_TAGS_PER_COLLECTION_COUNT,
-        )
-        print(f"{len(deleted_tags)} old tags to delete.")
-
-        # LFS are removed from remote storage as soon as they are no longer referenced
-        # by any commit.
-        # Now that we deleted old tags, we will rewrite the 'common' branch to remove
-        # commits that are no longer referenced by any tag.
-        if len(deleted_tags) > 0:
-            truncate_branch(
-                repo,
-                f"{GIT_REF_PREFIX}{COMMON_BRANCH}",
-                tags_deletion_threshold=TAGS_DELETION_THRESHOLD,
-            )
+        # LFS objects are removed from remote storage as soon as they are no longer
+        # referenced by any commit.
+        common_branch_name = f"{GIT_REF_PREFIX}{COMMON_BRANCH}"
+        if truncate_branch(repo, common_branch_name, keep_days=COMMON_BRANCH_KEEP_DAYS):
+            # History was rewritten, the branch has to be force pushed (+ prefix)
+            changed_branches.remove(f"refs/heads/{common_branch_name}")
+            changed_branches.add(f"+refs/heads/{common_branch_name}")
 
         print(f"{len(changed_attachments)} attachments to upload.")
         github_lfs_batch_upload_many(
@@ -163,17 +146,14 @@ def git_export() -> None:
             auth_header=auth_header,
         )
 
-        changed_tags = [f"+{tag}" for tag in created_tags] + [
-            f"-{tag}" for tag in deleted_tags
-        ]
-        push_mirror(repo, changed_branches, changed_tags, callbacks=callbacks)
+        push_mirror(repo, changed_branches, callbacks=callbacks)
 
         print("Done.")
     except Exception as exc:
         print("Error occurred:", exc)
         traceback.print_exc()
         print("Rolling back local changes...")
-        reset_repo(repo, callbacks=callbacks)
+        reset_repo(repo)
         raise exc
 
 
@@ -234,14 +214,14 @@ def fetch_all_cert_chains(
 
 async def repo_sync_content(
     repo: pygit2.Repository,
-) -> tuple[list[tuple[str, int, str]], set[str], list[str]]:
+) -> tuple[list[tuple[str, int, str]], set[str]]:
     """
     Sync content from the remote server to the local git repository.
-    Return the list of changed attachments to be uploaded to LFS, the list of changed branches, and the list of changed tags.
+    Return the list of changed attachments to be uploaded to LFS, and the list of
+    changed branches.
     """
     changed_attachments: list[tuple[str, int, str]] = []
     changed_branches: set[str] = set()
-    created_tags: list[str] = []
     author = committer = pygit2.Signature(GIT_USER, GIT_EMAIL)
 
     common_branch_name = f"refs/heads/{GIT_REF_PREFIX}{COMMON_BRANCH}"
@@ -258,7 +238,7 @@ async def repo_sync_content(
     )
     if not FORCE and monitor_changeset["timestamp"] == latest_timestamp:
         print("No new changes since last run.")
-        return changed_attachments, changed_branches, created_tags
+        return changed_attachments, changed_branches
 
     server_info = await client.server_info()  # ty: ignore[invalid-await]
 
@@ -331,24 +311,16 @@ async def repo_sync_content(
     else:
         ts = monitor_changeset["timestamp"]
         dt = ts2dt(ts).isoformat()
-        message = f"common@{ts} ({dt})"
-        common_tag_name = (
-            f"{GIT_REF_PREFIX}timestamps/common/{monitor_changeset['timestamp']}"
-        )
-
-        commit_and_tag(
-            repo,
+        commit_oid = repo.create_commit(
+            common_branch_name,
             author,
             committer,
-            message,
+            f"common@{ts} ({dt})",
             monitor_tree_id,
             common_branch_parents,
-            common_branch_name,
-            common_tag_name,
-            move_tag_if_exists=True,
         )
+        print(f"Created commit {common_branch_name}: {commit_oid}")
         changed_branches.add(common_branch_name)
-        created_tags.append(common_tag_name)
 
     # Process from oldest changeset to newest so that commits of the bucket branch
     # are sorted chronologically.
@@ -363,25 +335,26 @@ async def repo_sync_content(
 
     if common_base_tree is None:
         # First run, initialize all bucket branches.
-        changeset_changed_branches, changeset_created_tags = initialize_bucket_branches(
-            repo,
-            author=author,
-            committer=committer,
-            changesets_by_bucket=changesets_by_bucket,
+        changed_branches.update(
+            initialize_bucket_branches(
+                repo,
+                author=author,
+                committer=committer,
+                changesets_by_bucket=changesets_by_bucket,
+            )
         )
     else:
-        # Now process each collection changeset, creating/updating branches and tags accordingly.
-        changeset_changed_branches, changeset_created_tags = update_bucket_branches(
-            repo,
-            author=author,
-            committer=committer,
-            changesets_by_bucket=changesets_by_bucket,
+        # Now process each collection changeset, creating/updating branches accordingly.
+        changed_branches.update(
+            update_bucket_branches(
+                repo,
+                author=author,
+                committer=committer,
+                changesets_by_bucket=changesets_by_bucket,
+            )
         )
 
-    changed_branches.update(changeset_changed_branches)
-    created_tags += changeset_created_tags
-
-    return changed_attachments, changed_branches, created_tags
+    return changed_attachments, changed_branches
 
 
 def extract_branch_info(
@@ -389,7 +362,8 @@ def extract_branch_info(
 ) -> tuple[list[pygit2.Oid], pygit2.Tree | None, int]:
     """
     Extract information about the given branch in the repository.
-    Return the list of parent commits, the base tree, and the latest timestamp found in tags
+    Return the list of parent commits, the base tree, and the timestamp of the
+    monitor changeset that the previous run exported.
     """
     # The repo may exist without the 'common' ref (first run).
     try:
@@ -397,25 +371,22 @@ def extract_branch_info(
         common_base_tree = repo.get(common_tip).tree  # ty: ignore[unresolved-attribute]
         parents = [common_tip]
     except KeyError:  # pragma: no cover
-        common_base_tree = None
-        parents = []
+        print("No previous run found.")
+        return [], None, 0
 
-    # Previous run timestamp, find latest tag starting with `timestamps/common/*`
-    refs = [ref.decode() for ref in repo.raw_listall_references()]
-    timestamps = [
-        int(t.split("/")[-1])
-        for t in refs
-        if t.startswith(f"refs/tags/{GIT_REF_PREFIX}timestamps/common/")
-    ]
-    if timestamps:
-        latest_timestamp = max(timestamps)
-        print(
-            f"Found latest tag: {latest_timestamp}.",
-            "Ignoring (forced)" if FORCE else "",
-        )
-    else:
-        print("No previous tags found.")
-        latest_timestamp = 0
+    # The previous run stored the monitor changeset it exported: its timestamp is
+    # where this run picks up.
+    try:
+        blob = cast(pygit2.Blob, common_base_tree["monitor-changes.json"])
+    except KeyError:  # pragma: no cover
+        print("No monitor changeset from previous run.")
+        return parents, common_base_tree, 0  # ty: ignore[invalid-return-type]
+
+    latest_timestamp = json.loads(blob.data.decode("utf-8"))["timestamp"]
+    print(
+        f"Previous run exported {latest_timestamp}.",
+        "Ignoring (forced)" if FORCE else "",
+    )
     return parents, common_base_tree, latest_timestamp  # ty: ignore[invalid-return-type]
 
 
@@ -599,14 +570,13 @@ def initialize_bucket_branches(
     author: pygit2.Signature,
     committer: pygit2.Signature,
     changesets_by_bucket: dict[str, list[dict[str, Any]]],
-) -> tuple[set[str], list[str]]:
+) -> set[str]:
     """
-    Initialize the bucket branches and tags from the given changesets.
-    Return the set of created branches and the list of created tags.
+    Initialize the bucket branches from the given changesets.
+    Return the set of created branches.
     """
     created_changes: set[str] = set()
-    created_tags: list[str] = []
-    # On first run, we process all changesets to create the initial branches and tags.
+    # On first run, we process all changesets to create the initial branches.
     # Each branch will all records of all collections of the related bucket.
     for bid, bucket_changesets in changesets_by_bucket.items():
         branch_content: list[tuple[str, bytes | None]] = []
@@ -632,25 +602,7 @@ def initialize_bucket_branches(
         print(f"Created bucket branch {branch_refname} at {commit_oid}")
         created_changes.add(branch_refname)
 
-        # We add all tags on this initial commit.
-        for changeset in bucket_changesets:
-            cid = changeset["metadata"]["id"]
-            timestamp = changeset["timestamp"]
-            tag_name = f"{GIT_REF_PREFIX}timestamps/{bid}/{cid}/{timestamp}"
-            tag_refname = f"refs/tags/{tag_name}"
-            if repo.references.get(tag_refname) is not None:
-                repo.references.delete(tag_refname)
-            repo.create_tag(
-                tag_name,
-                commit_oid,
-                pygit2.GIT_OBJECT_COMMIT,  # ty: ignore[invalid-argument-type]
-                author,
-                f"Initial tag for {bid}/{cid}@{timestamp}",
-            )
-            print(f"Created tag {tag_name} at {commit_oid}")
-            created_tags.append(tag_name)
-
-    return created_changes, created_tags
+    return created_changes
 
 
 def update_bucket_branches(
@@ -658,13 +610,12 @@ def update_bucket_branches(
     author: pygit2.Signature,
     committer: pygit2.Signature,
     changesets_by_bucket: dict[str, list[dict[str, Any]]],
-) -> tuple[set[str], list[str]]:
+) -> set[str]:
     """
-    Process the given changesets and create/update branches and tags accordingly.
-    Return the set of changed branches and created tags.
+    Process the given changesets and create/update branches accordingly.
+    Return the set of changed branches.
     """
     changed_branches: set[str] = set()
-    created_tags: list[str] = []
 
     # In the next runs, we only add commits on top of the existing branches with the
     # changed data.
@@ -690,66 +641,20 @@ def update_bucket_branches(
                 print(f"No changes for {bid}/{cid} branch, skipping.")
                 continue
 
-            # Commit and tag.
-            # If the tag already exists (that happens when records don't change but metadata does),
-            # we move it to the new commit.
-            tag_name = f"{GIT_REF_PREFIX}timestamps/{bid}/{cid}/{timestamp}"
-            tag_moved = commit_and_tag(
-                repo,
-                author=author,
-                committer=committer,
-                message=commit_message,
-                tree_id=files_tree_id,
-                parents=parents,  # ty: ignore[invalid-argument-type]
-                branch_name=branch_refname,
-                tag_name=tag_name,
-                move_tag_if_exists=True,
+            commit_oid = repo.create_commit(
+                branch_refname,
+                author,
+                committer,
+                commit_message,
+                files_tree_id,
+                parents,
             )
+            print(f"Created commit {branch_refname}: {commit_oid}")
             changed_branches.add(branch_refname)
-            if tag_moved:
-                created_tags.append(tag_name)
 
             # Next collection will be put on top of the branch.
             new_tip = repo.lookup_reference(branch_refname).target
             branch_tree = repo.get(new_tip).tree  # ty: ignore[unresolved-attribute]
             parents = [new_tip]
 
-    return changed_branches, created_tags
-
-
-def commit_and_tag(
-    repo: pygit2.Repository,
-    author: pygit2.Signature,
-    committer: pygit2.Signature,
-    message: str,
-    tree_id: pygit2.Oid,
-    parents: list[pygit2.Oid],
-    branch_name: str,
-    tag_name: str,
-    move_tag_if_exists: bool = True,
-) -> bool:
-    """
-    Create a commit and tag it.
-    """
-    commit_oid = repo.create_commit(
-        branch_name, author, committer, message, tree_id, parents
-    )
-    print(f"Created commit {branch_name}: {commit_oid}")
-
-    tag_exists = repo.references.get(f"refs/tags/{tag_name}") is not None
-    if tag_exists and not move_tag_if_exists:
-        print(f"Tag {tag_name} already exists, skipping.")
-        return False
-
-    if tag_exists:
-        repo.references.delete(f"refs/tags/{tag_name}")
-
-    repo.create_tag(
-        tag_name,
-        commit_oid,
-        pygit2.GIT_OBJECT_COMMIT,  # ty: ignore[invalid-argument-type]
-        author,
-        message,
-    )
-    print(f"{'Created' if not tag_exists else 'Moved'} tag {tag_name}")
-    return True
+    return changed_branches

--- a/cronjobs/tests/commands/test_git_export.py
+++ b/cronjobs/tests/commands/test_git_export.py
@@ -1,8 +1,8 @@
 import asyncio
 import importlib
+import json
 import os
 import shutil
-from types import SimpleNamespace
 from unittest import mock
 
 import pygit2
@@ -48,7 +48,7 @@ def mock_git_push():
 @pytest.fixture
 def mock_repo_sync_content():
     with mock.patch.object(git_export, "repo_sync_content") as mock_sync:
-        mock_sync.return_value = [], [], []
+        mock_sync.return_value = [], set()
         yield mock_sync
 
 
@@ -63,15 +63,9 @@ def mock_github_lfs():
 
 
 @pytest.fixture
-def mock_list_heads():
-    with mock.patch("pygit2.Remote.list_heads") as mock_ls:
-        mock_ls.return_value = []
-        yield mock_ls
-
-
-@pytest.fixture
 def mock_truncate_branch():
     with mock.patch.object(git_export, "truncate_branch") as mock_truncate:
+        mock_truncate.return_value = False
         yield mock_truncate
 
 
@@ -265,22 +259,30 @@ def create_branch_with_empty_commit(repo, branch_name, set_as_repo_head=False):
         repo.set_head(branch_name)
 
 
-def simulate_pushed(repo, mock_list_heads):
-    # Simulate that these branches and tags were pushed in previous `git_export` call.
+def set_previous_run(repo, timestamp):
+    """Simulate a previous run that exported the monitor changeset at `timestamp`."""
+    author = committer = pygit2.Signature("Test User", "test@example.com")
+    remote_ref = "refs/remotes/origin/v1/common"
+    parent = repo[repo.lookup_reference(remote_ref).target]
+    tree_id = tree_upsert_blobs(
+        repo,
+        [("monitor-changes.json", json.dumps({"timestamp": timestamp}).encode())],
+        base_tree=parent.tree,
+    )
+    commit_id = repo.create_commit(
+        None, author, committer, f"common@{timestamp}", tree_id, [parent.id]
+    )
+    # Remote always wins when the repo is reset, so both refs must point to it.
+    repo.references.create(remote_ref, commit_id, force=True)
+    repo.references.create("refs/heads/v1/common", commit_id, force=True)
+
+
+def simulate_pushed(repo):
+    # Simulate that these branches were pushed in previous `git_export` call.
     for branch in repo.branches.local:
         commit = repo.lookup_reference(f"refs/heads/{branch}").peel()
         refname = f"refs/remotes/origin/{branch}"
-        try:
-            repo.references.create(refname, commit.id)
-        except pygit2.AlreadyExistsError:
-            repo.references.delete(refname)
-            repo.references.create(refname, commit.id)
-    ref_names = [
-        SimpleNamespace(name=tag, local=False)
-        for tag in repo.listall_references()
-        if tag.startswith("refs/tags/")
-    ]
-    mock_list_heads.return_value = ref_names
+        repo.references.create(refname, commit.id, force=True)
 
 
 @pytest.fixture
@@ -304,7 +306,6 @@ def test_remote_is_clone_if_dir_missing(
     mock_truncate_branch,
     mock_github_lfs,
     mock_git_push,
-    mock_list_heads,
 ):
     def _fake_clone(url, path, *args, **kwargs):
         return init_fake_repo(path)
@@ -326,7 +327,6 @@ def test_repo_sync_content_starts_from_scratch_if_no_previous_run(
     capsys,
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
@@ -335,29 +335,17 @@ def test_repo_sync_content_starts_from_scratch_if_no_previous_run(
 
     mock_git_fetch.assert_called_once()
     stdout = capsys.readouterr().out
-    assert "No previous tags found" in stdout
+    assert "No previous run found" in stdout
     assert "3 collections changed" in stdout
 
     (args, _) = mock_git_push.call_args_list[0]
     assert args == (
         [
-            "+refs/heads/v1/buckets/bid1:refs/heads/v1/buckets/bid1",
-            "+refs/heads/v1/buckets/bid2:refs/heads/v1/buckets/bid2",
-            "+refs/heads/v1/common:refs/heads/v1/common",
-            "+refs/tags/v1/timestamps/bid1/cid1/1700000000000:refs/tags/v1/timestamps/bid1/cid1/1700000000000",
-            "+refs/tags/v1/timestamps/bid2/cid2/1600000000000:refs/tags/v1/timestamps/bid2/cid2/1600000000000",
-            "+refs/tags/v1/timestamps/bid2/cid3/1500000000000:refs/tags/v1/timestamps/bid2/cid3/1500000000000",
-            "+refs/tags/v1/timestamps/common/1700000000000:refs/tags/v1/timestamps/common/1700000000000",
+            "refs/heads/v1/buckets/bid1:refs/heads/v1/buckets/bid1",
+            "refs/heads/v1/buckets/bid2:refs/heads/v1/buckets/bid2",
+            "refs/heads/v1/common:refs/heads/v1/common",
         ],
     )
-
-    # Verify that all collections tags point to the same commit (initial commit with all collections)
-    all_timestamps_tags = set(
-        repo.lookup_reference(tag).peel().id  # commit id of the tag
-        for tag in repo.listall_references()
-        if tag.startswith("refs/tags/v1/timestamps/bid2")
-    )
-    assert len(all_timestamps_tags) == 1
 
     # Verify that branch root contains all collections folders.
     tree = repo.lookup_reference("refs/heads/v1/buckets/bid2").peel().tree
@@ -366,11 +354,27 @@ def test_repo_sync_content_starts_from_scratch_if_no_previous_run(
 
 
 @responses.activate
+def test_common_branch_is_force_pushed_if_history_was_truncated(
+    repo,
+    mock_git_fetch,
+    mock_rs_server_content,
+    mock_truncate_branch,
+    mock_github_lfs,
+    mock_git_push,
+):
+    mock_truncate_branch.return_value = True
+
+    git_export.git_export()
+
+    (args, _) = mock_git_push.call_args_list[0]
+    assert "+refs/heads/v1/common:refs/heads/v1/common" in args[0]
+
+
+@responses.activate
 def test_repo_sync_does_nothing_if_up_to_date(
     capsys,
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_truncate_branch,
     mock_github_lfs,
@@ -381,13 +385,13 @@ def test_repo_sync_does_nothing_if_up_to_date(
     create_branch_with_empty_commit(repo, "v1/buckets/bid2")
 
     git_export.git_export()
-    simulate_pushed(repo, mock_list_heads)
+    simulate_pushed(repo)
     capsys.readouterr()  # Clear previous output
 
     git_export.git_export()
 
     stdout = capsys.readouterr().out
-    assert "Found latest tag: 1700000000000" in stdout
+    assert "Previous run exported 1700000000000" in stdout
     assert "No new changes since last run" in stdout
     assert "0 attachments to upload" in stdout
     assert "Everything up-to-date" in stdout
@@ -398,7 +402,6 @@ def test_repo_sync_can_be_forced_even_if_up_to_date(
     capsys,
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_truncate_branch,
     mock_github_lfs,
@@ -409,7 +412,7 @@ def test_repo_sync_can_be_forced_even_if_up_to_date(
     create_branch_with_empty_commit(repo, "v1/buckets/bid2")
 
     git_export.git_export()
-    simulate_pushed(repo, mock_list_heads)
+    simulate_pushed(repo)
     capsys.readouterr()  # Clear previous output
 
     git_export.FORCE = True
@@ -426,7 +429,6 @@ def test_repo_sync_content_uses_previous_run_to_fetch_changes(
     capsys,
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
@@ -435,23 +437,12 @@ def test_repo_sync_content_uses_previous_run_to_fetch_changes(
     create_branch_with_empty_commit(repo, "v1/buckets/bid1")
     create_branch_with_empty_commit(repo, "v1/buckets/bid2")
 
-    repo.create_tag(
-        "v1/timestamps/common/1600000000000",
-        repo.head.target,
-        pygit2.GIT_OBJECT_COMMIT,
-        pygit2.Signature("Test User", "test@example.com"),
-        "Test tag at 1600000000000",
-    )
-    mock_list_heads.return_value = [
-        SimpleNamespace(
-            name="refs/tags/v1/timestamps/common/1600000000000", local=False
-        )
-    ]
+    set_previous_run(repo, 1600000000000)
 
     git_export.git_export()
 
     stdout = capsys.readouterr().out
-    assert "Found latest tag: 1600000000000" in stdout
+    assert "Previous run exported 1600000000000" in stdout
     assert "1 collections changed" in stdout
 
     urls = [call.request.url.split("?")[0] for call in responses.calls]
@@ -463,10 +454,8 @@ def test_repo_sync_content_uses_previous_run_to_fetch_changes(
     (args, _) = mock_git_push.call_args_list[0]
     assert args == (
         [
-            "+refs/heads/v1/buckets/bid1:refs/heads/v1/buckets/bid1",
-            "+refs/heads/v1/common:refs/heads/v1/common",
-            "+refs/tags/v1/timestamps/bid1/cid1/1700000000000:refs/tags/v1/timestamps/bid1/cid1/1700000000000",
-            "+refs/tags/v1/timestamps/common/1700000000000:refs/tags/v1/timestamps/common/1700000000000",
+            "refs/heads/v1/buckets/bid1:refs/heads/v1/buckets/bid1",
+            "refs/heads/v1/common:refs/heads/v1/common",
         ],
     )
 
@@ -476,7 +465,6 @@ def test_repo_sync_content_ignores_previous_run_if_forced(
     capsys,
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
@@ -485,24 +473,13 @@ def test_repo_sync_content_ignores_previous_run_if_forced(
     create_branch_with_empty_commit(repo, "v1/buckets/bid1")
     create_branch_with_empty_commit(repo, "v1/buckets/bid2")
 
-    repo.create_tag(
-        "v1/timestamps/common/1600000000000",
-        repo.head.target,
-        pygit2.GIT_OBJECT_COMMIT,
-        pygit2.Signature("Test User", "test@example.com"),
-        "Test tag at 1600000000000",
-    )
-    mock_list_heads.return_value = [
-        SimpleNamespace(
-            name="refs/tags/v1/timestamps/common/1600000000000", local=False
-        )
-    ]
+    set_previous_run(repo, 1600000000000)
 
     git_export.FORCE = True
     git_export.git_export()
 
     stdout = capsys.readouterr().out
-    assert "Found latest tag: 1600000000000. Ignoring (forced)" in stdout
+    assert "Previous run exported 1600000000000. Ignoring (forced)" in stdout
     assert "3 collections changed" in stdout
     git_export.FORCE = False
 
@@ -511,7 +488,6 @@ def test_repo_sync_content_ignores_previous_run_if_forced(
 def test_repo_sync_stores_server_info(
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
@@ -526,7 +502,6 @@ def test_repo_sync_stores_server_info(
 def test_repo_sync_stores_monitor_changes(
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
@@ -541,7 +516,6 @@ def test_repo_sync_stores_monitor_changes(
 def test_repo_sync_stores_broadcasts(
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
@@ -556,7 +530,6 @@ def test_repo_sync_stores_broadcasts(
 def test_repo_sync_stores_cert_chains(
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
@@ -568,44 +541,19 @@ def test_repo_sync_stores_cert_chains(
 
 
 @responses.activate
-def test_repo_sync_tags_common_branch(
+def test_repo_updates_common_branch_if_only_bundle_changed(
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
 ):
     git_export.git_export()
 
-    tags = [
-        tag
-        for tag in repo.listall_references()
-        if tag.startswith("refs/tags/v1/timestamps/common/")
-    ]
-    assert "refs/tags/v1/timestamps/common/1700000000000" in tags
-
-
-@responses.activate
-def test_repo_moves_common_branch_tag_if_only_bundle_changed(
-    repo,
-    mock_git_fetch,
-    mock_list_heads,
-    mock_rs_server_content,
-    mock_github_lfs,
-    mock_git_push,
-):
-    git_export.git_export()
-
-    # Latest tag is 1700000000000 on the first common commit.
-    tag_ref = "refs/tags/v1/timestamps/common/1700000000000"
     branch_ref = "refs/heads/v1/common"
     before_commit = repo.lookup_reference(branch_ref).target
-    assert repo.lookup_reference(tag_ref).peel(pygit2.GIT_OBJECT_COMMIT).id == (
-        before_commit
-    )
 
-    simulate_pushed(repo, mock_list_heads)
+    simulate_pushed(repo)
 
     # Now simulate that a new bundle was published, but no new entry on
     # monitor/changes (its timestamp is unchanged). This is detected during the
@@ -619,20 +567,15 @@ def test_repo_moves_common_branch_tag_if_only_bundle_changed(
 
     git_export.git_export()
 
-    # Now assert that the latest tag on the common branch
-    # was moved to a different commit (the head of the branch).
+    # The common branch has a new commit for the new bundle.
     after_commit = repo.lookup_reference(branch_ref).target
     assert after_commit != before_commit
-    assert repo.lookup_reference(tag_ref).peel(pygit2.GIT_OBJECT_COMMIT).id == (
-        after_commit
-    )
 
 
 @responses.activate
-def test_repo_sync_stores_collections_records_in_buckets_branches_with_tags(
+def test_repo_sync_stores_collections_records_in_buckets_branches(
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
@@ -645,10 +588,6 @@ def test_repo_sync_stores_collections_records_in_buckets_branches_with_tags(
     assert "refs/heads/v1/buckets/bid1" in branches
     assert "refs/heads/v1/buckets/bid2" in branches
 
-    tags = [tag for tag in repo.listall_references() if tag.startswith("refs/tags")]
-    assert "refs/tags/v1/timestamps/bid1/cid1/1700000000000" in tags
-    assert "refs/tags/v1/timestamps/bid2/cid2/1600000000000" in tags
-
     rid1 = read_file(repo, "v1/buckets/bid1", "cid1/rid1-1.json")
     assert '"hello":"world"' in rid1.decode()
 
@@ -660,18 +599,15 @@ def test_repo_sync_stores_collections_records_in_buckets_branches_with_tags(
 def test_repo_sync_deletes_records_from_past_runs(
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
 ):
     git_export.git_export()
-    simulate_pushed(repo, mock_list_heads)
+    simulate_pushed(repo)
 
     # File exists before next run (not raising).
-    read_file(
-        repo, "refs/tags/v1/timestamps/bid2/cid2/1600000000000", "cid2/rid2-1.json"
-    )
+    read_file(repo, "v1/buckets/bid2", "cid2/rid2-1.json")
 
     # Now simulate that cid2 deleted its record.
     responses.replace(
@@ -712,22 +648,19 @@ def test_repo_sync_deletes_records_from_past_runs(
 
     # File not there anymore.
     with pytest.raises(KeyError):
-        read_file(
-            repo, "refs/tags/v1/timestamps/bid2/cid2/1800000000000", "cid2/rid2-1.json"
-        )
+        read_file(repo, "v1/buckets/bid2", "cid2/rid2-1.json")
 
 
 @responses.activate
 def test_repo_sync_appends_tombstones_to_the_ledger(
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
 ):
     git_export.git_export()
-    simulate_pushed(repo, mock_list_heads)
+    simulate_pushed(repo)
 
     # No record was deleted yet, the collection has no ledger.
     with pytest.raises(KeyError):
@@ -776,7 +709,6 @@ def test_repo_sync_appends_tombstones_to_the_ledger(
 def test_repo_sync_stores_attachments_as_lfs_pointers(
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
@@ -802,7 +734,6 @@ def test_repo_sync_stores_attachments_as_lfs_pointers(
 def test_repo_syncs_attachment_bundles(
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
@@ -851,7 +782,6 @@ def test_repo_syncs_attachment_bundles(
 def test_attachment_bundles_is_skipped_if_no_attachment_in_changeset(
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
@@ -882,7 +812,6 @@ def test_attachment_bundles_is_skipped_if_no_attachment_in_changeset(
 def test_repo_prunes_inactive_attachments_on_full_sync(
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
@@ -923,13 +852,12 @@ def test_repo_prunes_inactive_attachments_on_full_sync(
 def test_repo_keeps_inactive_attachments_on_incremental_sync(
     repo,
     mock_git_fetch,
-    mock_list_heads,
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
 ):
     git_export.git_export()
-    simulate_pushed(repo, mock_list_heads)
+    simulate_pushed(repo)
     blob = read_file(repo, "v1/common", "attachments/bid2/random-name.bin")
     assert "lfs" in blob.decode()
 
@@ -965,14 +893,13 @@ def test_repo_is_reset_to_local_content_on_error(
     mock_rs_server_content,
     mock_github_lfs,
     mock_git_push,
-    mock_list_heads,
 ):
     create_branch_with_empty_commit(repo, "v1/common", set_as_repo_head=True)
     create_branch_with_empty_commit(repo, "v1/buckets/bid1")
     create_branch_with_empty_commit(repo, "v1/buckets/bid2")
 
     git_export.git_export()
-    simulate_pushed(repo, mock_list_heads)
+    simulate_pushed(repo)
 
     responses.replace(
         responses.GET,
@@ -1029,8 +956,7 @@ def test_repo_is_reset_to_local_content_on_error(
         "Resetting local branch v1/buckets/bid1 to remote origin/v1/buckets/bid1"
         in stdout
     )
-    assert "Delete local tag refs/tags/v1/timestamps/bid1/cid0/1800000000000" in stdout
-    assert "Delete local tag refs/tags/v1/timestamps/common/1800000000000" in stdout
+    assert "Delete local tag" not in stdout
 
 
 def test_tombstones_are_split_by_month_and_stored_in_ascending_order(repo):

--- a/cronjobs/tests/commands/test_git_export_git_tools.py
+++ b/cronjobs/tests/commands/test_git_export_git_tools.py
@@ -5,7 +5,6 @@ import pygit2
 import pytest
 from commands import git_export
 from commands._git_export_git_tools import (
-    delete_old_tags,
     iter_tree,
     parse_lfs_pointer,
     push_mirror,
@@ -39,13 +38,6 @@ def tmp_repo(tmp_path):
     )
     repo.remotes.create("origin", git_export.GIT_REMOTE_URL)
     return repo
-
-
-@pytest.fixture
-def mock_list_heads():
-    with mock.patch("pygit2.Remote.list_heads") as mock_ls:
-        mock_ls.return_value = []
-        yield mock_ls
 
 
 @pytest.fixture
@@ -89,7 +81,7 @@ def test_iter_tree_single_file(tmp_repo):
     ]
 
 
-def test_reset_repo_creates_local_branches(tmp_repo, mock_list_heads):
+def test_reset_repo_creates_local_branches(tmp_repo):
     repo = tmp_repo
     commit = repo.revparse_single("main")
     # remote branch can be created via reference only.
@@ -100,7 +92,7 @@ def test_reset_repo_creates_local_branches(tmp_repo, mock_list_heads):
     )
     assert "v1/buckets/main" not in repo.branches.local
 
-    reset_repo(repo, callbacks=None)
+    reset_repo(repo)
 
     local_ref = repo.lookup_reference("refs/heads/v1/buckets/main")
     remote_ref = repo.lookup_reference("refs/remotes/origin/v1/buckets/main")
@@ -108,69 +100,31 @@ def test_reset_repo_creates_local_branches(tmp_repo, mock_list_heads):
 
 
 @pytest.mark.parametrize(
-    ("branches", "tags", "expected"),
+    ("branches", "expected"),
     [
+        (["+v1/common"], ["+v1/common:v1/common"]),
+        (["v1/common"], ["v1/common:v1/common"]),
         (
-            [
-                "v1/common",
-            ],
-            [
-                "-refs/tags/timestamp/123",
-                "+refs/tags/timestamp/456",
-            ],
-            [
-                [
-                    "+v1/common:v1/common",
-                    "+refs/tags/timestamp/456:refs/tags/timestamp/456",
-                ],
-                [":refs/tags/timestamp/123"],
-            ],
-        ),
-        (
-            [],
-            [
-                # Test that tags are normalized.
-                "+timestamp/789",
-            ],
-            [
-                [
-                    "+refs/tags/timestamp/789:refs/tags/timestamp/789",
-                ]
-                # And no call for delete.
-            ],
-        ),
-        (
-            [],
-            [
-                "-refs/tags/timestamp/123",
-            ],
-            [
-                [
-                    ":refs/tags/timestamp/123",
-                ]
-                # Only 1 call for delete.
-            ],
+            ["v1/buckets/main", "v1/common"],
+            ["v1/buckets/main:v1/buckets/main", "v1/common:v1/common"],
         ),
     ],
 )
-def test_push_mirror_pushes_branches_and_tags_then_deletes(
-    tmp_repo, mock_remote_push, branches, tags, expected
+def test_push_mirror_force_pushes_branches(
+    tmp_repo, mock_remote_push, branches, expected
 ):
-    repo = tmp_repo
+    push_mirror(tmp_repo, branches, callbacks=None)
 
-    push_mirror(
-        repo,
-        branches,
-        tags,
-        callbacks=None,
-    )
-
-    assert mock_remote_push.call_count == len(expected)
-    for expect in expected:
-        mock_remote_push.assert_any_call(expect, callbacks=None)
+    mock_remote_push.assert_called_once_with(expected, callbacks=None)
 
 
-def test_reset_repo_resets_local_branches_to_remote(tmp_repo, mock_list_heads):
+def test_push_mirror_does_nothing_without_branches(tmp_repo, mock_remote_push):
+    push_mirror(tmp_repo, [], callbacks=None)
+
+    mock_remote_push.assert_not_called()
+
+
+def test_reset_repo_resets_local_branches_to_remote(tmp_repo):
     repo = tmp_repo
     commit = repo.revparse_single("main")
     author = committer = pygit2.Signature("Test", "test@example.com")
@@ -193,7 +147,7 @@ def test_reset_repo_resets_local_branches_to_remote(tmp_repo, mock_list_heads):
     remote_ref = repo.lookup_reference("refs/remotes/origin/v1/buckets/main")
     assert local_ref.target != remote_ref.target
 
-    reset_repo(repo, callbacks=None)
+    reset_repo(repo)
 
     # Now they match.
     local_ref = repo.lookup_reference("refs/heads/v1/buckets/main")
@@ -201,7 +155,7 @@ def test_reset_repo_resets_local_branches_to_remote(tmp_repo, mock_list_heads):
     assert local_ref.target == remote_ref.target
 
 
-def test_reset_repo_deletes_extra_local_branches_and_tags(tmp_repo, mock_list_heads):
+def test_reset_repo_deletes_extra_local_branches(tmp_repo):
     repo = tmp_repo
     some_target = repo.references["refs/heads/main"].target
     repo.create_reference("refs/remotes/origin/v1/buckets/main", some_target)
@@ -220,166 +174,79 @@ def test_reset_repo_deletes_extra_local_branches_and_tags(tmp_repo, mock_list_he
     # Create an extra branch.
     repo.create_reference("refs/heads/v1/buckets/unknown", commit_id)
 
-    reset_repo(repo, callbacks=None)
+    reset_repo(repo)
 
     assert "v1/buckets/main" in repo.branches.local
     assert "v1/buckets/unknown" not in repo.branches.local
 
 
-def test_delete_old_tags(tmp_repo):
-    repo = tmp_repo
-    now_ts = int(time.time() * 1000)
-
-    commit = tmp_repo.revparse_single("main")
-    tags = [f"v1/timestamps/common/{now_ts - i * 86400000}" for i in range(6, 11)]
-    for old_tag in tags:
-        repo.create_tag(
-            old_tag,
-            commit.id,
-            pygit2.GIT_OBJECT_COMMIT,
-            pygit2.Signature("Tester", "test@example.com"),
-            "An old tag",
-        )
-
-    recent_tag = f"v1/timestamps/common/{now_ts}"
-    repo.create_tag(
-        recent_tag,
-        commit.id,
-        pygit2.GIT_OBJECT_COMMIT,
-        pygit2.Signature("Tester", "test@example.com"),
-        "A recent tag",
-    )
-
-    assert f"refs/tags/{recent_tag}" in repo.references
-    for old_tag in tags:
-        assert f"refs/tags/{old_tag}" in repo.references
-
-    deleted = delete_old_tags(repo, max_age_days=5, min_tags_per_collection=2)
-
-    assert len(deleted) == 4
-
-    # Keep the 2 most-recent old tags (closest to the threshold boundary).
-    assert f"refs/tags/{recent_tag}" in repo.references
-    assert f"refs/tags/{tags[0]}" in repo.references
-
-
-def test_delete_new_and_old_tags(tmp_repo):
-    repo = tmp_repo
-    now_ts = int(time.time() * 1000)
-
-    commit = tmp_repo.revparse_single("main")
-    tags = [f"v1/timestamps/common/{now_ts - i * 86400000}" for i in range(1, 10)]
-    for tag in tags:
-        repo.create_tag(
-            tag,
-            commit.id,
-            pygit2.GIT_OBJECT_COMMIT,
-            pygit2.Signature("Tester", "test@example.com"),
-            "An old tag",
-        )
-
-    recent_tag = f"v1/timestamps/common/{now_ts}"
-    repo.create_tag(
-        recent_tag,
-        commit.id,
-        pygit2.GIT_OBJECT_COMMIT,
-        pygit2.Signature("Tester", "test@example.com"),
-        "A recent tag",
-    )
-
-    assert f"refs/tags/{recent_tag}" in repo.references
-    for tag in tags:
-        assert f"refs/tags/{tag}" in repo.references
-
-    deleted = delete_old_tags(repo, max_age_days=5, min_tags_per_collection=2)
-
-    # Keep all recent tags, but delete all tags beyond max_age_days
-    assert len(deleted) == 5
-    assert f"refs/tags/{recent_tag}" in repo.references
-    for t in tags[0:4]:
-        assert f"refs/tags/{t}" in repo.references
-    for t in tags[4:]:
-        assert f"refs/tags/{t}" not in repo.references
+DAY_SECONDS = 24 * 60 * 60
 
 
 @pytest.fixture
-def repo_with_tagged_commits(tmp_repo):
+def repo_with_dated_commits(tmp_repo):
+    """A branch of 4 commits, aged 30, 20, 10 and 0 days."""
     repo = tmp_repo
-    author = pygit2.Signature("Test", "test@example.com")
-    committer = author
+    now = int(time.time())
 
     commit_oid = repo.revparse_single("main").id
-    repo.create_tag(
-        "v1/timestamps/tagged-commit-0",
-        commit_oid,
-        pygit2.GIT_OBJECT_COMMIT,
-        author,
-        "Fixture's commit",
-    )
-
-    for i in range(3):
+    for i, age_days in enumerate((30, 20, 10, 0)):
+        when = now - age_days * DAY_SECONDS
+        author = committer = pygit2.Signature("Test", "test@example.com", when, 0)
         tree_oid = tree_upsert_blobs(
             repo,
-            items=[("file.txt", b"content")],
+            items=[("file.txt", f"content-{i}".encode())],
             base_tree=repo.revparse_single("main").tree,
         )
         commit_oid = repo.create_commit(
             "refs/heads/main",
             author,
             committer,
-            f"commit-{i + 1}",
+            f"commit-{age_days}-days-old",
             tree_oid,
             [commit_oid],
-        )
-        repo.create_tag(
-            f"v1/timestamps/tagged-commit-{i + 1}",
-            commit_oid,
-            pygit2.GIT_OBJECT_COMMIT,
-            author,
-            f"tag-{i + 1}",
         )
     return repo
 
 
-def test_truncate_branch_all_tagged_does_nothing(repo_with_tagged_commits):
-    repo = repo_with_tagged_commits
+def test_truncate_branch_keeps_recent_commits(repo_with_dated_commits):
+    repo = repo_with_dated_commits
+    before = len(list(repo.walk(repo.references["refs/heads/main"].target)))
 
-    all_main_commits = list(repo.walk(repo.references["refs/heads/main"].target))
-    before_len = len(all_main_commits)
+    assert truncate_branch(repo, "main", keep_days=90) is False
 
-    truncate_branch(repo, "main", tags_deletion_threshold=1)
-
-    all_main_commits_after = list(repo.walk(repo.references["refs/heads/main"].target))
-    assert len(all_main_commits_after) == before_len
+    after = len(list(repo.walk(repo.references["refs/heads/main"].target)))
+    assert after == before
 
 
-def test_truncate_branch_if_more_untagged_than_threshold(repo_with_tagged_commits):
-    repo = repo_with_tagged_commits
+def test_truncate_branch_drops_commits_older_than_keep_days(repo_with_dated_commits):
+    repo = repo_with_dated_commits
+    before_sha1s = [c.id for c in repo.walk(repo.references["refs/heads/main"].target)]
 
-    repo.references.delete("refs/tags/v1/timestamps/tagged-commit-0")
-    repo.references.delete("refs/tags/v1/timestamps/tagged-commit-1")
+    assert truncate_branch(repo, "main", keep_days=25) is True
 
-    all_main_commits = list(repo.walk(repo.references["refs/heads/main"].target))
-    before_len = len(all_main_commits)
+    commits = list(repo.walk(repo.references["refs/heads/main"].target))
+    assert [c.message for c in commits] == [
+        "commit-0-days-old",
+        "commit-10-days-old",
+        "commit-20-days-old",
+    ]
+    # History was rewritten, the kept commits have new ids.
+    assert [c.id for c in commits] != before_sha1s[:3]
+    # The tree content is preserved.
+    assert (commits[0].tree / "file.txt").data == b"content-3"
 
-    truncate_branch(repo, "main", tags_deletion_threshold=3)
 
-    all_main_commits_after = list(repo.walk(repo.references["refs/heads/main"].target))
-    assert len(all_main_commits_after) == before_len
+def test_truncate_branch_always_keeps_the_tip(repo_with_dated_commits):
+    repo = repo_with_dated_commits
+
+    assert truncate_branch(repo, "main", keep_days=0) is True
+
+    commits = list(repo.walk(repo.references["refs/heads/main"].target))
+    assert [c.message for c in commits] == ["commit-0-days-old"]
 
 
-def test_truncate_branch_to_keep_only_latest_tagged_commits(repo_with_tagged_commits):
-    repo = repo_with_tagged_commits
+def test_truncate_branch_does_nothing_if_keep_days_is_negative(repo_with_dated_commits):
+    repo = repo_with_dated_commits
 
-    repo.references.delete("refs/tags/v1/timestamps/tagged-commit-0")
-    repo.references.delete("refs/tags/v1/timestamps/tagged-commit-1")
-    all_main_commits = list(repo.walk(repo.references["refs/heads/main"].target))
-    before_sha1s = [c.id for c in all_main_commits]
-
-    truncate_branch(repo, "main", tags_deletion_threshold=1)
-
-    all_main_commits_after = list(repo.walk(repo.references["refs/heads/main"].target))
-    commits_msgs = [c.message for c in all_main_commits_after]
-    assert commits_msgs == ["commit-3", "commit-2"]
-    after_sha1s = [c.id for c in all_main_commits_after]
-    assert before_sha1s[-2:] != after_sha1s
+    assert truncate_branch(repo, "main", keep_days=-1) is False

--- a/cronjobs/tests/commands/test_git_export_git_tools.py
+++ b/cronjobs/tests/commands/test_git_export_git_tools.py
@@ -237,6 +237,18 @@ def test_truncate_branch_drops_commits_older_than_keep_days(repo_with_dated_comm
     assert (commits[0].tree / "file.txt").data == b"content-3"
 
 
+def test_truncate_branch_tolerates_commits_within_the_margin(repo_with_dated_commits):
+    repo = repo_with_dated_commits
+    before_sha1s = [c.id for c in repo.walk(repo.references["refs/heads/main"].target)]
+
+    # The oldest commit is 30 days old, ie. older than 28 days, but still within
+    # the 10% margin (30.8 days).
+    assert truncate_branch(repo, "main", keep_days=28) is False
+
+    commits = list(repo.walk(repo.references["refs/heads/main"].target))
+    assert [c.id for c in commits] == before_sha1s
+
+
 def test_truncate_branch_always_keeps_the_tip(repo_with_dated_commits):
     repo = repo_with_dated_commits
 


### PR DESCRIPTION
🎉 

- git-export does not manipulate tags at all anymore
- we now only truncate `v1/common`, and we only force push when the branch was truncated
- we don't truncate on every run, we have a 10% margin on the default 90 days
- truncating is now enough to prune objects from LFS storage. To purge orphan files, a Github support request is required. I opened a support request to confirm with them. 
- LFS storage is cheap anyway https://github.com/pricing/calculator?feature=lfs and should give us a few years
